### PR TITLE
Replace newman postman run with hurl API spec tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.realworld-spec/
+.git/
+.gradle/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
 
 env:
   APP_NAME: ${{ github.event.repository.name }}
+  # RealWorld API spec (hurl collection), pinned to a known-good revision.
+  SPEC_REPO: realworld-apps/realworld
+  SPEC_REF: 5d510ce6ec41bb97723e92fbd8d3e3458a381c09
+  HURL_VERSION: 8.0.1
   CR_REGISTRY: ghcr.io
   CR_NAMESPACE: ${{ github.repository_owner }}
   CR_USERNAME: ${{ github.actor }}
@@ -33,10 +37,18 @@ jobs:
           distribution: temurin
           java-version: 25
 
-      - name: Setup NodeJS
-        uses: actions/setup-node@v7
+      - name: Checkout API spec
+        uses: actions/checkout@v7
         with:
-          node-version: 24
+          repository: ${{ env.SPEC_REPO }}
+          ref: ${{ env.SPEC_REF }}
+          sparse-checkout: specs/api/hurl
+          path: .realworld-spec
+
+      - name: Setup hurl
+        uses: gacts/install-hurl@v1
+        with:
+          version: ${{ env.HURL_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -49,15 +61,16 @@ jobs:
           nohup java -jar service/build/libs/realworld-backend-spring*.jar &
           sleep 5
 
-      - name: Run postman collection
+      - name: Run API spec tests
+        # TODO: drop continue-on-error once the API conforms to the spec.
+        continue-on-error: true
+        shell: bash
         run: >
-          npx newman run
-          https://raw.githubusercontent.com/gothinkster/realworld/master/api/Conduit.postman_collection.json
-          --delay-request 200
-          --global-var "APIURL=http://localhost:8080/api"
-          --global-var "USERNAME=username"
-          --global-var "EMAIL=username@example.com"
-          --global-var "PASSWORD=password"
+          hurl --test
+          --jobs 1
+          --variable host=http://localhost:8080
+          --variable uid=${{ github.run_id }}
+          .realworld-spec/specs/api/hurl/*.hurl
 
       - name: Upload app-jar
         uses: actions/upload-artifact@v7
@@ -99,10 +112,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
-      - name: Setup NodeJS
-        uses: actions/setup-node@v7
+      - name: Checkout API spec
+        uses: actions/checkout@v7
         with:
-          node-version: 24
+          repository: ${{ env.SPEC_REPO }}
+          ref: ${{ env.SPEC_REF }}
+          sparse-checkout: specs/api/hurl
+          path: .realworld-spec
+
+      - name: Setup hurl
+        uses: gacts/install-hurl@v1
+        with:
+          version: ${{ env.HURL_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -134,15 +155,16 @@ jobs:
           sleep 5
         shell: bash
 
-      - name: Run postman collection
+      - name: Run API spec tests
+        # TODO: drop continue-on-error once the API conforms to the spec.
+        continue-on-error: true
+        shell: bash
         run: >
-          npx newman run
-          https://raw.githubusercontent.com/gothinkster/realworld/master/api/Conduit.postman_collection.json
-          --delay-request 200
-          --global-var "APIURL=http://localhost:8080/api"
-          --global-var "USERNAME=username"
-          --global-var "EMAIL=username@example.com"
-          --global-var "PASSWORD=password"
+          hurl --test
+          --jobs 1
+          --variable host=http://localhost:8080
+          --variable uid=${{ github.run_id }}${{ strategy.job-index }}
+          .realworld-spec/specs/api/hurl/*.hurl
 
   coverage:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Thumbs.db
 .DS_Store
 .gradle
+.kotlin
 build/
 target/
 out/
@@ -11,3 +12,6 @@ out/
 .project
 .settings
 .classpath
+
+# RealWorld API spec checkout
+.realworld-spec/


### PR DESCRIPTION
The gothinkster/realworld Conduit.postman_collection.json URL now 404s —
upstream moved to realworld-apps/realworld and migrated the API spec to a
hurl collection, so both newman steps have been failing on a dead URL.

Swap them for the upstream hurl suite, sparse-checked-out into .realworld-spec,
the same path the README uses locally, so a local run and a CI run exercise the
same files from the same revision. The revision is pinned: upstream publishes
no tags, so tracking main would let an unrelated upstream commit turn this
build red. Bump SPEC_REF deliberately instead.

That checkout is a foreign clone carrying its own .git, so .gitignore keeps it
out of the working tree and .dockerignore keeps it out of the image build
context along with .git and .gradle, none of which Dockerfile.native reads.

The step is continue-on-error for now: the app does not yet conform to the new
spec (field-keyed error envelope, 204 on delete, 409 on duplicate, and more).
This lands the signal first so the conformance work has something to measure
against; a later change removes the flag and makes it gating.

Setup NodeJS is dropped from both jobs — it existed only to run npx newman.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>