### PR TITLE
Conform to the RealWorld API spec

### DIFF
--- a/service-api/build.gradle.kts
+++ b/service-api/build.gradle.kts
@@ -12,4 +12,8 @@ dependencies {
     implementation(libs.jackson.jacksonAnnotations)
     implementation(libs.jakarta.jakartaValidationApi)
     implementation(libs.spring.springWeb)
+
+    testImplementation(libs.spring.springBootStarterTest)
+    testImplementation(libs.spring.springBootStarterValidation)
+    testRuntimeOnly(libs.junit.junitPlatformLauncher)
 }

--- a/service-api/src/main/java/com/github/al/realworld/api/command/UpdateArticle.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/command/UpdateArticle.java
@@ -23,22 +23,37 @@
  */
 package com.github.al.realworld.api.command;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.al.realworld.api.dto.JsonNullable;
 import com.github.al.realworld.bus.Command;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.With;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
+
+/**
+ * Partial update of an article. An absent field leaves the current value unchanged; an empty
+ * {@code tagList} removes all tags.
+ */
 public record UpdateArticle(
         @With
         String slug,
         @Valid @NotNull Data article
 ) implements Command<UpdateArticleResult> {
 
+    /**
+     * Constraints on the type argument apply to a present field only, so each field rejects an
+     * explicit null.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Data(
-            @Nullable String title,
-            @Nullable String description,
-            @Nullable String body
+            @Nullable JsonNullable<@NotBlank String> title,
+            @Nullable JsonNullable<@NotBlank String> description,
+            @Nullable JsonNullable<@NotBlank String> body,
+            @Nullable JsonNullable<@NotNull List<String>> tagList
     ) {
 
     }

--- a/service-api/src/main/java/com/github/al/realworld/api/command/UpdateUser.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/command/UpdateUser.java
@@ -23,32 +23,43 @@
  */
 package com.github.al.realworld.api.command;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.al.realworld.api.dto.JsonNullable;
 import com.github.al.realworld.bus.Command;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Partial update of the authenticated user. An absent field leaves the current value unchanged.
+ */
 public record UpdateUser(
         @Valid @NotNull Data user
 ) implements Command<UpdateUserResult> {
 
+    /**
+     * Constraints on the type argument apply to a present field only, so {@code email},
+     * {@code username} and {@code password} reject an explicit null while {@code bio} and
+     * {@code image} accept one.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Data(
-            @Email @Nullable String email,
-            @Nullable String username,
-            @Nullable String password,
-            @Nullable String image,
-            @Nullable String bio
+            @Nullable JsonNullable<@NotBlank @Email String> email,
+            @Nullable JsonNullable<@NotBlank String> username,
+            @Nullable JsonNullable<@NotBlank @Size(min = 8, message = "is too short (minimum is 8 characters)") String> password,
+            @Nullable JsonNullable<String> image,
+            @Nullable JsonNullable<String> bio
     ) {
 
-        @AssertTrue(message = "at least one field must be provided")
-        public boolean hasAtLeastOneField() {
-            return email != null
-                   || username != null
-                   || password != null
-                   || image != null
-                   || bio != null;
+        public boolean isEmpty() {
+            return email == null
+                   && username == null
+                   && password == null
+                   && image == null
+                   && bio == null;
         }
 
     }

--- a/service-api/src/main/java/com/github/al/realworld/api/dto/GenericError.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/dto/GenericError.java
@@ -23,16 +23,31 @@
  */
 package com.github.al.realworld.api.dto;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * The error response envelope, mapping each field at fault to its messages.
+ */
 public record GenericError(
-        Errors errors
+        Map<String, List<String>> errors
 ) {
 
-    public record Errors(
-            List<String> body
-    ) {
+    public static GenericError of(String field, String message) {
+        return new GenericError(Map.of(field, List.of(message)));
+    }
 
+    /**
+     * Groups {@code field} to {@code message} pairs, preserving encounter order and merging
+     * repeated fields into a single list.
+     */
+    public static GenericError ofPairs(List<Map.Entry<String, String>> pairs) {
+        Map<String, List<String>> grouped = new LinkedHashMap<>();
+        for (var pair : pairs) {
+            grouped.computeIfAbsent(pair.getKey(), _ -> new java.util.ArrayList<>()).add(pair.getValue());
+        }
+        return new GenericError(Map.copyOf(grouped));
     }
 
 }

--- a/service-api/src/main/java/com/github/al/realworld/api/dto/JsonNullable.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/dto/JsonNullable.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A payload field that distinguishes an absent JSON property from one explicitly set to null.
+ *
+ * <p>A {@code null} reference denotes an absent property. A non-null instance denotes a present
+ * property, holding {@code null} when the client sent a JSON null.
+ *
+ * <p>Serialization unwraps to the contained value. Deserialization requires a value deserializer
+ * that maps an absent property to {@code null} and a JSON null to an instance holding
+ * {@code null}.
+ *
+ * @param <T>   the contained value type
+ * @param value the contained value, {@code null} for a JSON null
+ */
+public record JsonNullable<T>(@Nullable T value) {
+
+    /**
+     * Returns the value contained in {@code field}, or {@code null} if the field is absent.
+     */
+    public static <T> @Nullable T unwrap(@Nullable JsonNullable<T> field) {
+        return field == null ? null : field.value();
+    }
+
+    public boolean isNull() {
+        return value == null;
+    }
+
+    @JsonValue
+    public @Nullable T json() {
+        return value;
+    }
+
+}

--- a/service-api/src/main/java/com/github/al/realworld/api/dto/JsonNullableValueExtractor.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/dto/JsonNullableValueExtractor.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.api.dto;
+
+import jakarta.validation.valueextraction.ExtractedValue;
+import jakarta.validation.valueextraction.ValueExtractor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Exposes the value contained in a {@link JsonNullable} to Bean Validation, so that constraints
+ * declared on the type argument apply to that value.
+ *
+ * <p>An absent field holds no container and is therefore not validated. Registered through
+ * {@code META-INF/services}.
+ */
+public class JsonNullableValueExtractor implements ValueExtractor<JsonNullable<@ExtractedValue ?>> {
+
+    @Override
+    public void extractValues(JsonNullable<@Nullable ?> originalValue, ValueReceiver receiver) {
+        receiver.value(null, originalValue.value());
+    }
+
+}

--- a/service-api/src/main/java/com/github/al/realworld/api/dto/ProfileDto.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/dto/ProfileDto.java
@@ -23,10 +23,12 @@
  */
 package com.github.al.realworld.api.dto;
 
+import org.jspecify.annotations.Nullable;
+
 public record ProfileDto(
         String username,
-        String bio,
-        String image,
+        @Nullable String bio,
+        @Nullable String image,
         Boolean following
 ) {
 

--- a/service-api/src/main/java/com/github/al/realworld/api/dto/UserDto.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/dto/UserDto.java
@@ -23,12 +23,14 @@
  */
 package com.github.al.realworld.api.dto;
 
+import org.jspecify.annotations.Nullable;
+
 public record UserDto(
         String email,
         String token,
         String username,
-        String bio,
-        String image
+        @Nullable String bio,
+        @Nullable String image
 ) {
 
 }

--- a/service-api/src/main/java/com/github/al/realworld/api/operation/ArticleOperations.java
+++ b/service-api/src/main/java/com/github/al/realworld/api/operation/ArticleOperations.java
@@ -71,6 +71,7 @@ public interface ArticleOperations {
     UpdateArticleResult updateBySlug(@PathVariable("slug") String slug,
                                      @Valid @RequestBody UpdateArticle command);
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteExchange("/articles/{slug}")
     void deleteBySlug(@PathVariable("slug") String slug);
 
@@ -83,10 +84,12 @@ public interface ArticleOperations {
     @GetExchange("/articles/{slug}/comments")
     GetCommentsResult findAllComments(@PathVariable("slug") String slug);
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostExchange("/articles/{slug}/comments")
     AddCommentResult addComment(@PathVariable("slug") String slug,
                                 @Valid @RequestBody AddComment data);
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteExchange("/articles/{slug}/comments/{id}")
     void deleteComment(@PathVariable("slug") String slug,
                        @PathVariable("id") long id);

--- a/service-api/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
+++ b/service-api/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
@@ -1,0 +1,1 @@
+com.github.al.realworld.api.dto.JsonNullableValueExtractor

--- a/service-api/src/main/resources/ValidationMessages.properties
+++ b/service-api/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,4 @@
+# RealWorld spec wording for validation failures.
+jakarta.validation.constraints.NotBlank.message=can't be blank
+jakarta.validation.constraints.NotNull.message=is missing
+jakarta.validation.constraints.Email.message=is invalid

--- a/service-api/src/test/java/com/github/al/realworld/api/command/UpdateUserValidationTest.java
+++ b/service-api/src/test/java/com/github/al/realworld/api/command/UpdateUserValidationTest.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.api.command;
+
+import com.github.al.realworld.api.dto.JsonNullable;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateUserValidationTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    private static UpdateUser withEmail(JsonNullable<String> email) {
+        return new UpdateUser(new UpdateUser.Data(email, null, null, null, null));
+    }
+
+    @Test
+    void should_rejectMalformedEmail_underTheFieldsOwnKey() {
+        var violations = validator.validate(withEmail(new JsonNullable<>("not-an-email")));
+
+        assertThat(violations).hasSize(1);
+        var violation = violations.iterator().next();
+        assertThat(violation.getMessage()).isEqualTo("is invalid");
+
+        var path = violation.getPropertyPath().toString();
+        assertThat(path.substring(path.lastIndexOf('.') + 1)).isEqualTo("email");
+    }
+
+    @Test
+    void should_acceptWellFormedEmail() {
+        assertThat(validator.validate(withEmail(new JsonNullable<>("someone@example.com")))).isEmpty();
+    }
+
+    @Test
+    void should_acceptAbsentEmail() {
+        assertThat(validator.validate(withEmail(null))).isEmpty();
+    }
+
+    @Test
+    void should_rejectExplicitNullEmail() {
+        assertThat(validator.validate(withEmail(new JsonNullable<>(null))))
+                .singleElement()
+                .satisfies(violation -> assertThat(violation.getMessage()).isEqualTo("can't be blank"));
+    }
+
+}

--- a/service/src/intTest/java/com/github/al/realworld/test/client/ArticleApiTest.java
+++ b/service/src/intTest/java/com/github/al/realworld/test/client/ArticleApiTest.java
@@ -28,6 +28,7 @@ import com.github.al.realworld.api.command.CreateArticle;
 import com.github.al.realworld.api.command.UpdateArticle;
 import com.github.al.realworld.api.dto.ArticleItemDto;
 import com.github.al.realworld.api.dto.GenericError;
+import com.github.al.realworld.api.dto.JsonNullable;
 import com.github.al.realworld.api.operation.ArticleClient;
 import com.github.al.realworld.api.operation.ProfileClient;
 import com.github.al.realworld.api.operation.TagClient;
@@ -41,6 +42,7 @@ import org.springframework.web.client.RestClientResponseException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
@@ -115,9 +117,7 @@ public class ArticleApiTest extends BaseClientTest {
 
             var error = exception.getResponseBodyAs(GenericError.class);
             assertThat(error).isNotNull();
-            assertThat(error.errors()).isNotNull();
-            assertThat(error.errors().body()).hasSize(1);
-            assertThat(error.errors().body().getFirst()).isNotBlank();
+            assertThat(error.errors()).containsExactly(Map.entry("article", List.of("not found")));
         }
 
         @Test
@@ -126,11 +126,7 @@ public class ArticleApiTest extends BaseClientTest {
 
             var created = articleClient.create(createArticleCommand()).article();
 
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(
-                    ALTERED_TITLE,
-                    ALTERED_DESCRIPTION,
-                    ALTERED_BODY
-            ));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(new JsonNullable<>(ALTERED_TITLE), new JsonNullable<>(ALTERED_DESCRIPTION), new JsonNullable<>(ALTERED_BODY), null));
 
             var updated = articleClient.updateBySlug(created.slug(), updateCommand).article();
 
@@ -146,7 +142,7 @@ public class ArticleApiTest extends BaseClientTest {
             var created = articleClient.create(createArticleCommand()).article();
 
             auth.register().login();
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(ALTERED_TITLE, null, null));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(new JsonNullable<>(ALTERED_TITLE), null, null, null));
 
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
@@ -159,7 +155,7 @@ public class ArticleApiTest extends BaseClientTest {
         @Test
         void should_throw404_when_updateDoesNotExist() {
             auth.register().login();
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(ALTERED_TITLE, null, null));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(new JsonNullable<>(ALTERED_TITLE), null, null, null));
 
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
@@ -174,7 +170,7 @@ public class ArticleApiTest extends BaseClientTest {
             auth.register().login();
             var created = articleClient.create(createArticleCommand()).article();
 
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(ALTERED_TITLE, null, null));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(new JsonNullable<>(ALTERED_TITLE), null, null, null));
             var updated = articleClient.updateBySlug(created.slug(), updateCommand).article();
 
             assertThat(updated.title()).isEqualTo(ALTERED_TITLE);
@@ -187,7 +183,7 @@ public class ArticleApiTest extends BaseClientTest {
             auth.register().login();
             var created = articleClient.create(createArticleCommand()).article();
 
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(null, ALTERED_DESCRIPTION, null));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(null, new JsonNullable<>(ALTERED_DESCRIPTION), null, null));
             var updated = articleClient.updateBySlug(created.slug(), updateCommand).article();
 
             assertThat(updated.title()).isEqualTo(created.title());
@@ -200,7 +196,7 @@ public class ArticleApiTest extends BaseClientTest {
             auth.register().login();
             var created = articleClient.create(createArticleCommand()).article();
 
-            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(null, null, ALTERED_BODY));
+            var updateCommand = new UpdateArticle(null, new UpdateArticle.Data(null, null, new JsonNullable<>(ALTERED_BODY), null));
             var updated = articleClient.updateBySlug(created.slug(), updateCommand).article();
 
             assertThat(updated.title()).isEqualTo(created.title());

--- a/service/src/intTest/java/com/github/al/realworld/test/client/UserApiTest.java
+++ b/service/src/intTest/java/com/github/al/realworld/test/client/UserApiTest.java
@@ -26,6 +26,7 @@ package com.github.al.realworld.test.client;
 import com.github.al.realworld.api.command.LoginUser;
 import com.github.al.realworld.api.command.RegisterUser;
 import com.github.al.realworld.api.command.UpdateUser;
+import com.github.al.realworld.api.dto.JsonNullable;
 import com.github.al.realworld.api.operation.UserClient;
 import com.github.al.realworld.domain.repository.UserRepository;
 import com.github.al.realworld.infrastructure.db.jdbc.UserJdbcRepository;
@@ -81,7 +82,7 @@ public class UserApiTest extends BaseClientTest {
         }
 
         @Test
-        void should_throw422_whenRegisterWithExistingEmail() {
+        void should_throw409_whenRegisterWithExistingEmail() {
             var command = registerCommand();
             userClient.register(command);
 
@@ -96,11 +97,11 @@ public class UserApiTest extends BaseClientTest {
                     () -> userClient.register(duplicateEmailCommand)
             );
 
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         }
 
         @Test
-        void should_throw422_whenRegisterWithExistingUsername() {
+        void should_throw409_whenRegisterWithExistingUsername() {
             var command = registerCommand();
             userClient.register(command);
 
@@ -115,7 +116,7 @@ public class UserApiTest extends BaseClientTest {
                     () -> userClient.register(duplicateUsernameCommand)
             );
 
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         }
 
     }
@@ -147,14 +148,14 @@ public class UserApiTest extends BaseClientTest {
         }
 
         @Test
-        void should_return422_whenLoginNonExistentUser() {
+        void should_return401_whenLoginNonExistentUser() {
             var s = UUID.randomUUID().toString();
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
                     () -> userClient.login(new LoginUser(new LoginUser.Data(s + "@ex.com", s)))
             );
 
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         }
 
     }
@@ -186,7 +187,7 @@ public class UserApiTest extends BaseClientTest {
         }
 
         @Test
-        void should_throw422_whenGetCurrentUser_and_userDoesNotExist() {
+        void should_throw401_whenGetCurrentUser_and_userDoesNotExist() {
             var registeredUser = auth.register().login();
 
             // Delete the user but keep the token active
@@ -198,8 +199,7 @@ public class UserApiTest extends BaseClientTest {
                     () -> userClient.current()
             );
 
-            // GetCurrentUserHandler throws BadRequestException
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         }
 
     }
@@ -211,13 +211,7 @@ public class UserApiTest extends BaseClientTest {
         void should_returnCorrectData_whenUpdateUser() {
             auth.register().login();
 
-            var updateUser = new UpdateUser(new UpdateUser.Data(
-                    ALTERED_EMAIL,
-                    ALTERED_USERNAME,
-                    ALTERED_PASSWORD,
-                    ALTERED_IMAGE,
-                    ALTERED_BIO
-            ));
+            var updateUser = new UpdateUser(new UpdateUser.Data(new JsonNullable<>(ALTERED_EMAIL), new JsonNullable<>(ALTERED_USERNAME), new JsonNullable<>(ALTERED_PASSWORD), new JsonNullable<>(ALTERED_IMAGE), new JsonNullable<>(ALTERED_BIO)));
 
             var user = userClient.update(updateUser).user();
 
@@ -228,54 +222,42 @@ public class UserApiTest extends BaseClientTest {
         }
 
         @Test
-        void should_throw422_whenUpdateUserWithExistingEmail() {
+        void should_throw409_whenUpdateUserWithExistingEmail() {
             var registeredUser = auth.register();
 
             auth.register().login();
 
-            var updateUser = new UpdateUser(new UpdateUser.Data(
-                    registeredUser.getEmail(),
-                    null,
-                    null,
-                    null,
-                    null
-            ));
+            var updateUser = new UpdateUser(new UpdateUser.Data(new JsonNullable<>(registeredUser.getEmail()), null, null, null, null));
 
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
                     () -> userClient.update(updateUser)
             );
 
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         }
 
         @Test
-        void should_throw422_whenUpdateUserWithExistingName() {
+        void should_throw409_whenUpdateUserWithExistingName() {
             var registeredUser = auth.register();
 
             auth.register().login();
 
-            var updateUser = new UpdateUser(new UpdateUser.Data(
-                    null,
-                    registeredUser.getUsername(),
-                    null,
-                    null,
-                    null
-            ));
+            var updateUser = new UpdateUser(new UpdateUser.Data(null, new JsonNullable<>(registeredUser.getUsername()), null, null, null));
 
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
                     () -> userClient.update(updateUser)
             );
 
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         }
 
         @Test
         void should_updateOnlyBio() {
             auth.register().login();
 
-            var updateUser = new UpdateUser(new UpdateUser.Data(null, null, null, null, ALTERED_BIO));
+            var updateUser = new UpdateUser(new UpdateUser.Data(null, null, null, null, new JsonNullable<>(ALTERED_BIO)));
             var user = userClient.update(updateUser).user();
 
             assertThat(user.bio()).isEqualTo(ALTERED_BIO);
@@ -296,24 +278,21 @@ public class UserApiTest extends BaseClientTest {
         }
 
         @Test
-        void should_throw404_whenUpdateUser_and_userDoesNotExist() {
+        void should_throw401_whenUpdateUser_and_userDoesNotExist() {
             var registeredUser = auth.register().login();
 
             // Delete the user but keep the token active
             userRepository.findByEmail(registeredUser.getEmail())
                     .ifPresent(user -> userJdbcRepository.deleteById(user.id()));
 
-            var updateUser = new UpdateUser(new UpdateUser.Data(
-                    null, null, null, null, ALTERED_BIO
-            ));
+            var updateUser = new UpdateUser(new UpdateUser.Data(null, null, null, null, new JsonNullable<>(ALTERED_BIO)));
 
             var exception = catchThrowableOfType(
                     RestClientResponseException.class,
                     () -> userClient.update(updateUser)
             );
 
-            // UpdateUserHandler throws NotFoundException
-            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         }
 
     }

--- a/service/src/main/java/com/github/al/realworld/application/command/AddCommentHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/AddCommentHandler.java
@@ -53,7 +53,7 @@ public class AddCommentHandler implements CommandHandler<AddCommentResult, AddCo
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var articleId = articleRepository.findIdBySlug(command.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exist", command.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exist", command.slug()));
 
         var comment = Comment.builder()
                 .articleId(articleId)

--- a/service/src/main/java/com/github/al/realworld/application/command/DeleteArticleHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/DeleteArticleHandler.java
@@ -52,10 +52,10 @@ public class DeleteArticleHandler implements CommandHandler<DeleteArticleResult,
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var article = articleRepository.findBySlug(command.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exist", command.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exist", command.slug()));
 
         if (article.authorId() != currentUserId) {
-            throw forbidden("article [slug=%s] is not owned by %s", command.slug(),
+            throw forbidden("article", "article [slug=%s] is not owned by %s", command.slug(),
                     authenticationService.getCurrentUserName());
         }
 

--- a/service/src/main/java/com/github/al/realworld/application/command/DeleteCommentHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/DeleteCommentHandler.java
@@ -27,6 +27,7 @@ import com.github.al.realworld.api.command.DeleteComment;
 import com.github.al.realworld.api.command.DeleteCommentResult;
 import com.github.al.realworld.application.service.AuthenticationService;
 import com.github.al.realworld.bus.CommandHandler;
+import com.github.al.realworld.domain.repository.ArticleRepository;
 import com.github.al.realworld.domain.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ import static com.github.al.realworld.application.exception.NotFoundException.no
 public class DeleteCommentHandler implements CommandHandler<DeleteCommentResult, DeleteComment> {
 
     private final AuthenticationService authenticationService;
+    private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
 
     @Transactional
@@ -47,11 +49,15 @@ public class DeleteCommentHandler implements CommandHandler<DeleteCommentResult,
     public DeleteCommentResult handle(DeleteComment command) {
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
+        if (articleRepository.findBySlug(command.slug()).isEmpty()) {
+            throw notFound("article", "article [slug=%s] does not exist", command.slug());
+        }
+
         var comment = commentRepository.findById(command.id())
-                .orElseThrow(() -> notFound("comment [id=%s] does not exist", command.id()));
+                .orElseThrow(() -> notFound("comment", "comment [id=%s] does not exist", command.id()));
 
         if (comment.authorId() != currentUserId) {
-            throw forbidden("comment [id=%s] is not owned by %s", comment.id(),
+            throw forbidden("comment", "comment [id=%s] is not owned by %s", comment.id(),
                     authenticationService.getCurrentUserName());
         }
 

--- a/service/src/main/java/com/github/al/realworld/application/command/FavoriteArticleHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/FavoriteArticleHandler.java
@@ -53,7 +53,7 @@ public class FavoriteArticleHandler implements CommandHandler<FavoriteArticleRes
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var articleId = articleRepository.findIdBySlug(command.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exist", command.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exist", command.slug()));
 
         var articleFavorite = new ArticleFavorite(articleId, currentUserId);
         if (!articleFavoriteRepository.exists(articleFavorite)) {

--- a/service/src/main/java/com/github/al/realworld/application/command/FollowProfileHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/FollowProfileHandler.java
@@ -58,7 +58,7 @@ public class FollowProfileHandler implements CommandHandler<FollowProfileResult,
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var followee = userRepository.findByUsername(command.followee())
-                .orElseThrow(() -> notFound("user [name=%s] does not exist", command.followee()));
+                .orElseThrow(() -> notFound("profile", "user [name=%s] does not exist", command.followee()));
 
         var followRelation = new FollowRelation(currentUserId, followee.id());
         if (!followRelationRepository.exists(followRelation)) {

--- a/service/src/main/java/com/github/al/realworld/application/command/LoginUserHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/LoginUserHandler.java
@@ -36,8 +36,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.github.al.realworld.application.exception.BadRequestException.badRequest;
-import static com.github.al.realworld.application.exception.UnauthorizedException.unauthorized;
+import static com.github.al.realworld.application.exception.UnauthorizedException.invalidCredentials;
 
 @RequiredArgsConstructor
 @Service
@@ -54,10 +53,10 @@ public class LoginUserHandler implements CommandHandler<LoginUserResult, LoginUs
         var userData = command.user();
 
         var user = userRepository.findByEmail(userData.email())
-                .orElseThrow(() -> badRequest("user [email=%s] does not exist", userData.email()));
+                .orElseThrow(() -> invalidCredentials("user [email=%s] does not exist", userData.email()));
 
         if (!passwordEncoder.matches(userData.password(), user.password())) {
-            throw unauthorized("user [email=%s] password is incorrect", userData.email());
+            throw invalidCredentials("user [email=%s] password is incorrect", userData.email());
         }
 
         var token = jwtService.getToken(user);

--- a/service/src/main/java/com/github/al/realworld/application/command/RegisterUserHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/RegisterUserHandler.java
@@ -39,7 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
-import static com.github.al.realworld.application.exception.BadRequestException.badRequest;
+import static com.github.al.realworld.application.exception.ConflictException.alreadyTaken;
 
 @RequiredArgsConstructor
 @Service
@@ -56,10 +56,10 @@ public class RegisterUserHandler implements CommandHandler<RegisterUserResult, R
         var userData = command.user();
 
         if (userRepository.existsByEmail(userData.email())) {
-            throw badRequest("user [email=%s] already exists", userData.email());
+            throw alreadyTaken("email", "user [email=%s] already exists", userData.email());
         }
         if (userRepository.existsByUsername(userData.username())) {
-            throw badRequest("user [name=%s] already exists", userData.username());
+            throw alreadyTaken("username", "user [name=%s] already exists", userData.username());
         }
 
         var encodedPassword = passwordEncoder.encode(userData.password());

--- a/service/src/main/java/com/github/al/realworld/application/command/UnfavoriteArticleHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/UnfavoriteArticleHandler.java
@@ -53,7 +53,7 @@ public class UnfavoriteArticleHandler implements CommandHandler<UnfavoriteArticl
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var articleId = articleRepository.findIdBySlug(command.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exist", command.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exist", command.slug()));
 
         var articleFavorite = new ArticleFavorite(articleId, currentUserId);
         if (articleFavoriteRepository.exists(articleFavorite)) {

--- a/service/src/main/java/com/github/al/realworld/application/command/UnfollowProfileHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/UnfollowProfileHandler.java
@@ -58,7 +58,7 @@ public class UnfollowProfileHandler implements CommandHandler<UnfollowProfileRes
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var followee = userRepository.findByUsername(command.followee())
-                .orElseThrow(() -> notFound("user [name=%s] does not exist", command.followee()));
+                .orElseThrow(() -> notFound("profile", "user [name=%s] does not exist", command.followee()));
 
         var followRelation = new FollowRelation(currentUserId, followee.id());
         followRelationRepository.delete(followRelation);

--- a/service/src/main/java/com/github/al/realworld/application/command/UpdateArticleHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/UpdateArticleHandler.java
@@ -30,13 +30,19 @@ import com.github.al.realworld.application.service.AuthenticationService;
 import com.github.al.realworld.application.service.ConversionService;
 import com.github.al.realworld.application.service.SlugService;
 import com.github.al.realworld.bus.CommandHandler;
+import com.github.al.realworld.domain.model.Tag;
 import com.github.al.realworld.domain.repository.ArticleRepository;
+import com.github.al.realworld.domain.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static com.github.al.realworld.api.dto.JsonNullable.unwrap;
 import static com.github.al.realworld.application.exception.ForbiddenException.forbidden;
 import static com.github.al.realworld.application.exception.NotFoundException.notFound;
+import static java.util.Objects.requireNonNullElse;
 
 @RequiredArgsConstructor
 @Service
@@ -44,6 +50,7 @@ public class UpdateArticleHandler implements CommandHandler<UpdateArticleResult,
 
     private final AuthenticationService authenticationService;
     private final ArticleRepository articleRepository;
+    private final TagRepository tagRepository;
     private final SlugService slugService;
     private final ConversionService conversionService;
 
@@ -54,27 +61,43 @@ public class UpdateArticleHandler implements CommandHandler<UpdateArticleResult,
         var articleData = command.article();
 
         var article = articleRepository.findBySlug(command.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exist", command.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exist", command.slug()));
 
         if (article.authorId() != currentUserId) {
-            throw forbidden("article [slug=%s] is not owned by %s",
+            throw forbidden("article", "article [slug=%s] is not owned by %s",
                     command.slug(), authenticationService.getCurrentUserName());
         }
 
-        var newTitle = articleData.title();
-        var alteredArticle = article.toBuilder()
-                .slug(newTitle != null ? slugService.makeSlug(newTitle) : article.slug())
-                .title(newTitle != null ? newTitle : article.title())
-                .description(articleData.description() != null ? articleData.description() : article.description())
-                .body(articleData.body() != null ? articleData.body() : article.body())
-                .build();
+        var newTitle = unwrap(articleData.title());
+        var newDescription = unwrap(articleData.description());
+        var newBody = unwrap(articleData.body());
+        var newTagNames = unwrap(articleData.tagList());
 
-        articleRepository.save(alteredArticle);
+        var builder = article.toBuilder()
+                .slug(newTitle == null ? article.slug() : slugService.makeSlug(newTitle))
+                .title(requireNonNullElse(newTitle, article.title()))
+                .description(requireNonNullElse(newDescription, article.description()))
+                .body(requireNonNullElse(newBody, article.body()));
+
+        if (newTagNames != null) {
+            builder.clearTags().tags(resolveTags(newTagNames));
+        }
+
+        articleRepository.save(builder.build());
 
         var articleAssembly = articleRepository.findAssemblyById(currentUserId, article.id()).orElseThrow();
         var data = conversionService.convert(articleAssembly, ArticleDto.class);
 
         return new UpdateArticleResult(data);
+    }
+
+    private List<Tag> resolveTags(List<String> names) {
+        return names.stream()
+                .distinct()
+                .map(Tag::new)
+                .map(tagRepository::saveOrGet)
+                .sorted()
+                .toList();
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/command/UpdateUserHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/command/UpdateUserHandler.java
@@ -25,6 +25,7 @@ package com.github.al.realworld.application.command;
 
 import com.github.al.realworld.api.command.UpdateUser;
 import com.github.al.realworld.api.command.UpdateUserResult;
+import com.github.al.realworld.api.dto.JsonNullable;
 import com.github.al.realworld.api.dto.UserDto;
 import com.github.al.realworld.application.service.AuthenticationService;
 import com.github.al.realworld.application.service.ConversionService;
@@ -33,14 +34,18 @@ import com.github.al.realworld.bus.CommandHandler;
 import com.github.al.realworld.domain.model.UserWithToken;
 import com.github.al.realworld.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
+import static com.github.al.realworld.api.dto.JsonNullable.unwrap;
 import static com.github.al.realworld.application.exception.BadRequestException.badRequest;
-import static com.github.al.realworld.application.exception.NotFoundException.notFound;
+import static com.github.al.realworld.application.exception.ConflictException.alreadyTaken;
+import static com.github.al.realworld.application.exception.UnauthorizedException.invalidToken;
+import static java.util.Objects.requireNonNullElse;
 
 @RequiredArgsConstructor
 @Service
@@ -58,36 +63,38 @@ public class UpdateUserHandler implements CommandHandler<UpdateUserResult, Updat
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var user = userRepository.findById(currentUserId)
-                .orElseThrow(() -> notFound("user [name=%s] does not exist",
+                .orElseThrow(() -> invalidToken("user [name=%s] does not exist",
                         authenticationService.getCurrentUserName()));
 
         var userData = command.user();
+        if (userData.isEmpty()) {
+            throw badRequest("body", "can't be empty", "update payload contains no fields");
+        }
 
-        var newUsername = userData.username();
+        var newUsername = unwrap(userData.username());
         if (newUsername != null
             && !newUsername.equals(user.username())
             && userRepository.existsByUsername(newUsername)) {
-            throw badRequest("user [name=%s] already exists", newUsername);
+            throw alreadyTaken("username", "user [name=%s] already exists", newUsername);
         }
 
-        var newEmail = userData.email();
+        var newEmail = unwrap(userData.email());
         if (newEmail != null
             && !newEmail.equals(user.email())
             && userRepository.existsByEmail(newEmail)) {
-            throw badRequest("user [email=%s] already exists", newEmail);
+            throw alreadyTaken("email", "user [email=%s] already exists", newEmail);
         }
 
-        var encodedPassword = userData.password() == null
-                ? user.password()
-                : encoder.encode(userData.password());
+        var newPassword = unwrap(userData.password());
+        var encodedPassword = newPassword == null ? user.password() : encoder.encode(newPassword);
         Objects.requireNonNull(encodedPassword);
 
         var alteredUser = user.toBuilder()
-                .email(newEmail != null ? newEmail : user.email())
-                .username(newUsername != null ? newUsername : user.username())
+                .email(requireNonNullElse(newEmail, user.email()))
+                .username(requireNonNullElse(newUsername, user.username()))
                 .password(encodedPassword)
-                .bio(userData.bio() != null ? userData.bio() : user.bio())
-                .image(userData.image() != null ? userData.image() : user.image())
+                .bio(normalized(userData.bio(), user.bio()))
+                .image(normalized(userData.image(), user.image()))
                 .build();
 
         var savedUser = userRepository.save(alteredUser);
@@ -96,6 +103,19 @@ public class UpdateUserHandler implements CommandHandler<UpdateUserResult, Updat
         var data = conversionService.convert(new UserWithToken(savedUser, token), UserDto.class);
 
         return new UpdateUserResult(data);
+    }
+
+    /**
+     * Returns the new value of a nullable field, treating an empty string as {@code null} and an
+     * absent field as {@code current}.
+     */
+    private static @Nullable String normalized(@Nullable JsonNullable<String> field,
+                                               @Nullable String current) {
+        if (field == null) {
+            return current;
+        }
+        var value = field.value();
+        return value == null || value.isEmpty() ? null : value;
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/exception/ApplicationException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/ApplicationException.java
@@ -23,11 +23,31 @@
  */
 package com.github.al.realworld.application.exception;
 
+/**
+ * Base class for errors rendered as an error envelope.
+ *
+ * <p>Carries the response field and message reported to the client, alongside the exception
+ * message, which is retained for logging only.
+ */
 public sealed abstract class ApplicationException extends RuntimeException
-        permits BadRequestException, ForbiddenException, NotFoundException, UnauthorizedException {
+        permits BadRequestException, ConflictException, ForbiddenException, NotFoundException,
+        UnauthorizedException {
 
-    public ApplicationException(String message) {
-        super(message);
+    private final String field;
+    private final String error;
+
+    protected ApplicationException(String field, String error, String detail) {
+        super(detail);
+        this.field = field;
+        this.error = error;
+    }
+
+    public String field() {
+        return field;
+    }
+
+    public String error() {
+        return error;
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/exception/BadRequestException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/BadRequestException.java
@@ -27,12 +27,13 @@ import org.jspecify.annotations.Nullable;
 
 public final class BadRequestException extends ApplicationException {
 
-    public BadRequestException(String message) {
-        super(message);
+    private BadRequestException(String field, String error, String detail) {
+        super(field, error, detail);
     }
 
-    public static BadRequestException badRequest(String message, @Nullable Object... args) {
-        return new BadRequestException(String.format(message, args));
+    public static BadRequestException badRequest(String field, String error, String detail,
+                                                 @Nullable Object... args) {
+        return new BadRequestException(field, error, String.format(detail, args));
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/exception/ConflictException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/ConflictException.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.application.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Signals a uniqueness violation, reported as {@code has already been taken}.
+ */
+public final class ConflictException extends ApplicationException {
+
+    private ConflictException(String field, String detail) {
+        super(field, "has already been taken", detail);
+    }
+
+    public static ConflictException alreadyTaken(String field, String detail, @Nullable Object... args) {
+        return new ConflictException(field, String.format(detail, args));
+    }
+
+}

--- a/service/src/main/java/com/github/al/realworld/application/exception/ForbiddenException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/ForbiddenException.java
@@ -27,12 +27,12 @@ import org.jspecify.annotations.Nullable;
 
 public final class ForbiddenException extends ApplicationException {
 
-    public ForbiddenException(String message) {
-        super(message);
+    private ForbiddenException(String field, String detail) {
+        super(field, "forbidden", detail);
     }
 
-    public static ForbiddenException forbidden(String message, @Nullable Object... args) {
-        return new ForbiddenException(String.format(message, args));
+    public static ForbiddenException forbidden(String field, String detail, @Nullable Object... args) {
+        return new ForbiddenException(field, String.format(detail, args));
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/exception/NotFoundException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/NotFoundException.java
@@ -27,12 +27,12 @@ import org.jspecify.annotations.Nullable;
 
 public final class NotFoundException extends ApplicationException {
 
-    public NotFoundException(String message) {
-        super(message);
+    private NotFoundException(String field, String detail) {
+        super(field, "not found", detail);
     }
 
-    public static NotFoundException notFound(String message, @Nullable Object... args) {
-        return new NotFoundException(String.format(message, args));
+    public static NotFoundException notFound(String field, String detail, @Nullable Object... args) {
+        return new NotFoundException(field, String.format(detail, args));
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/exception/UnauthorizedException.java
+++ b/service/src/main/java/com/github/al/realworld/application/exception/UnauthorizedException.java
@@ -27,12 +27,24 @@ import org.jspecify.annotations.Nullable;
 
 public final class UnauthorizedException extends ApplicationException {
 
-    public UnauthorizedException(String message) {
-        super(message);
+    private UnauthorizedException(String field, String error, String detail) {
+        super(field, error, detail);
     }
 
-    public static UnauthorizedException unauthorized(String message, @Nullable Object... args) {
-        return new UnauthorizedException(String.format(message, args));
+    /**
+     * Rejects a sign-in attempt, reporting {@code credentials} as {@code invalid} without
+     * indicating which credential was wrong.
+     */
+    public static UnauthorizedException invalidCredentials(String detail, @Nullable Object... args) {
+        return new UnauthorizedException("credentials", "invalid", String.format(detail, args));
+    }
+
+    public static UnauthorizedException invalidToken(String detail, @Nullable Object... args) {
+        return new UnauthorizedException("token", "is invalid", String.format(detail, args));
+    }
+
+    public static UnauthorizedException missingToken(String detail, @Nullable Object... args) {
+        return new UnauthorizedException("token", "is missing", String.format(detail, args));
     }
 
 }

--- a/service/src/main/java/com/github/al/realworld/application/query/GetArticleHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/query/GetArticleHandler.java
@@ -50,7 +50,7 @@ public class GetArticleHandler implements QueryHandler<GetArticleResult, GetArti
         var currentUserId = authenticationService.getCurrentUserId();
 
         var articleAssembly = articleRepository.findAssemblyBySlug(currentUserId, query.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exists", query.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exists", query.slug()));
         var data = conversionService.convert(articleAssembly, ArticleDto.class);
 
         return new GetArticleResult(data);

--- a/service/src/main/java/com/github/al/realworld/application/query/GetCommentsHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/query/GetCommentsHandler.java
@@ -52,7 +52,7 @@ public class GetCommentsHandler implements QueryHandler<GetCommentsResult, GetCo
         var currentUserId = authenticationService.getCurrentUserId();
 
         var articleId = articleRepository.findIdBySlug(query.slug())
-                .orElseThrow(() -> notFound("article [slug=%s] does not exists", query.slug()));
+                .orElseThrow(() -> notFound("article", "article [slug=%s] does not exists", query.slug()));
 
         var result = commentRepository.findAllAssemblyByArticleId(currentUserId, articleId).stream()
                 .map(comment -> conversionService.convert(comment, CommentDto.class))

--- a/service/src/main/java/com/github/al/realworld/application/query/GetCurrentUserHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/query/GetCurrentUserHandler.java
@@ -36,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.github.al.realworld.application.exception.BadRequestException.badRequest;
+import static com.github.al.realworld.application.exception.UnauthorizedException.invalidToken;
 
 @RequiredArgsConstructor
 @Component
@@ -53,7 +53,7 @@ public class GetCurrentUserHandler implements QueryHandler<GetCurrentUserResult,
         var currentUserId = authenticationService.getRequiredCurrentUserId();
 
         var user = userRepository.findById(currentUserId)
-                .orElseThrow(() -> badRequest("user [name=%s] does not exist",
+                .orElseThrow(() -> invalidToken("user [name=%s] does not exist",
                         authenticationService.getCurrentUserName()));
 
         var token = jwtService.getToken(user);

--- a/service/src/main/java/com/github/al/realworld/application/query/GetProfileHandler.java
+++ b/service/src/main/java/com/github/al/realworld/application/query/GetProfileHandler.java
@@ -50,7 +50,7 @@ public class GetProfileHandler implements QueryHandler<GetProfileResult, GetProf
         var currentUserId = authenticationService.getCurrentUserId();
 
         var profile = profileRepository.findByUsername(query.username(), currentUserId)
-                .orElseThrow(() -> notFound("user [name=%s] does not exist", query.username()));
+                .orElseThrow(() -> notFound("profile", "user [name=%s] does not exist", query.username()));
         var data = conversionService.convert(profile, ProfileDto.class);
 
         return new GetProfileResult(data);

--- a/service/src/main/java/com/github/al/realworld/application/service/AuthenticationService.java
+++ b/service/src/main/java/com/github/al/realworld/application/service/AuthenticationService.java
@@ -23,8 +23,9 @@
  */
 package com.github.al.realworld.application.service;
 
-import com.github.al.realworld.application.exception.UnauthorizedException;
 import org.jspecify.annotations.Nullable;
+
+import static com.github.al.realworld.application.exception.UnauthorizedException.missingToken;
 
 public interface AuthenticationService {
 
@@ -33,7 +34,7 @@ public interface AuthenticationService {
     default long getRequiredCurrentUserId() {
         var currentUserId = getCurrentUserId();
         if (currentUserId == null) {
-            throw new UnauthorizedException("current user id is not present");
+            throw missingToken("current user id is not present");
         }
         return currentUserId;
     }
@@ -43,7 +44,7 @@ public interface AuthenticationService {
     default String getRequiredCurrentUserName() {
         var currentUsername = getCurrentUserName();
         if (currentUsername == null) {
-            throw new UnauthorizedException("current user id is not present");
+            throw missingToken("current user id is not present");
         }
         return currentUsername;
     }

--- a/service/src/main/java/com/github/al/realworld/domain/model/Profile.java
+++ b/service/src/main/java/com/github/al/realworld/domain/model/Profile.java
@@ -23,10 +23,12 @@
  */
 package com.github.al.realworld.domain.model;
 
+import org.jspecify.annotations.Nullable;
+
 public record Profile(
         String username,
-        String bio,
-        String image,
+        @Nullable String bio,
+        @Nullable String image,
         boolean following
 ) {
 

--- a/service/src/main/java/com/github/al/realworld/domain/model/User.java
+++ b/service/src/main/java/com/github/al/realworld/domain/model/User.java
@@ -25,6 +25,7 @@ package com.github.al.realworld.domain.model;
 
 import lombok.Builder;
 import lombok.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -36,8 +37,8 @@ public record User(
         @NonNull String username,
         @NonNull String email,
         @NonNull String password,
-        String bio,
-        String image
+        @Nullable String bio,
+        @Nullable String image
 ) {
 
 }

--- a/service/src/main/java/com/github/al/realworld/infrastructure/config/GraalConfig.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/config/GraalConfig.java
@@ -44,6 +44,7 @@ public class GraalConfig {
         @Override
         public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
             hints.reflection().registerType(UpdateUser.Data.class, MemberCategory.INVOKE_PUBLIC_METHODS);
+            hints.resources().registerResourceBundle("ValidationMessages");
         }
 
     }

--- a/service/src/main/java/com/github/al/realworld/infrastructure/config/SecurityConfig.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/config/SecurityConfig.java
@@ -23,6 +23,7 @@
  */
 package com.github.al.realworld.infrastructure.config;
 
+import com.github.al.realworld.infrastructure.web.ApiAuthenticationEntryPoint;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -55,7 +55,6 @@ import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,7 +65,9 @@ import java.util.regex.Pattern;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   ApiAuthenticationEntryPoint authenticationEntryPoint)
+            throws Exception {
         http
                 .authorizeHttpRequests(requests ->
                         requests.requestMatchers("/h2-console", "/h2-console/**").permitAll())
@@ -75,9 +76,11 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
-                .exceptionHandling(configurer -> configurer.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+                .exceptionHandling(configurer -> configurer.authenticationEntryPoint(authenticationEntryPoint))
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2ResourceServer(configurer -> configurer.jwt(Customizer.withDefaults()))
+                .oauth2ResourceServer(configurer -> configurer
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .jwt(Customizer.withDefaults()))
                 .authorizeHttpRequests(configurer -> {
                     configurer.requestMatchers(EndpointRequest.to(
                                     HealthEndpoint.class,

--- a/service/src/main/java/com/github/al/realworld/infrastructure/json/JsonNullableDeserializer.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/json/JsonNullableDeserializer.java
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.infrastructure.json;
+
+import com.github.al.realworld.api.dto.JsonNullable;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
+
+/**
+ * Deserializes {@link JsonNullable}, mapping an absent property to {@code null} and a JSON null
+ * to an instance holding {@code null}.
+ *
+ * <p>The contained type is resolved from the declaring property, so a single instance serves
+ * any type argument.
+ */
+public class JsonNullableDeserializer extends ValueDeserializer<JsonNullable<?>> {
+
+    private final @Nullable JavaType contentType;
+
+    public JsonNullableDeserializer() {
+        this(null);
+    }
+
+    private JsonNullableDeserializer(@Nullable JavaType contentType) {
+        this.contentType = contentType;
+    }
+
+    @Override
+    public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+        if (property == null) {
+            return this;
+        }
+        return new JsonNullableDeserializer(property.getType().containedType(0));
+    }
+
+    @Override
+    public JsonNullable<?> deserialize(JsonParser p, DeserializationContext ctxt) {
+        if (contentType == null) {
+            return new JsonNullable<>(ctxt.readValue(p, Object.class));
+        }
+        return new JsonNullable<>(ctxt.readValue(p, contentType));
+    }
+
+    @Override
+    public Object getNullValue(DeserializationContext ctxt) {
+        return new JsonNullable<>(null);
+    }
+
+    @Override
+    public @Nullable Object getAbsentValue(DeserializationContext ctxt) {
+        return null;
+    }
+
+}

--- a/service/src/main/java/com/github/al/realworld/infrastructure/json/JsonNullableModule.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/json/JsonNullableModule.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.infrastructure.json;
+
+import com.github.al.realworld.api.dto.JsonNullable;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.module.SimpleModule;
+
+/**
+ * Registers {@link JsonNullableDeserializer} with the auto-configured object mappers.
+ */
+@Component
+public class JsonNullableModule extends SimpleModule {
+
+    public JsonNullableModule() {
+        super("JsonNullableModule");
+        addDeserializer(JsonNullable.class, new JsonNullableDeserializer());
+    }
+
+}

--- a/service/src/main/java/com/github/al/realworld/infrastructure/json/package-info.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/json/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.github.al.realworld.infrastructure.json;
+
+import org.jspecify.annotations.NullMarked;

--- a/service/src/main/java/com/github/al/realworld/infrastructure/web/ApiAuthenticationEntryPoint.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/web/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.infrastructure.web;
+
+import com.github.al.realworld.api.dto.GenericError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * Writes a {@link GenericError} response for requests rejected by the security filter chain,
+ * which are refused before reaching {@link RestExceptionHandler}.
+ *
+ * <p>Responds with 401 and a {@code token} entry, reported as {@code is missing} when no
+ * {@code Authorization} header was sent and {@code is invalid} otherwise.
+ */
+@RequiredArgsConstructor
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        var error = request.getHeader(HttpHeaders.AUTHORIZATION) == null ? "is missing" : "is invalid";
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), GenericError.of("token", error));
+    }
+
+}

--- a/service/src/main/java/com/github/al/realworld/infrastructure/web/RestExceptionHandler.java
+++ b/service/src/main/java/com/github/al/realworld/infrastructure/web/RestExceptionHandler.java
@@ -26,16 +26,18 @@ package com.github.al.realworld.infrastructure.web;
 import com.github.al.realworld.api.dto.GenericError;
 import com.github.al.realworld.application.exception.ApplicationException;
 import com.github.al.realworld.application.exception.BadRequestException;
+import com.github.al.realworld.application.exception.ConflictException;
 import com.github.al.realworld.application.exception.ForbiddenException;
 import com.github.al.realworld.application.exception.NotFoundException;
 import com.github.al.realworld.application.exception.UnauthorizedException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import org.jspecify.annotations.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -43,24 +45,31 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
+import java.util.Map;
 
-import lombok.extern.slf4j.Slf4j;
+import static java.util.Objects.requireNonNullElse;
 
+/**
+ * Renders exceptions as a {@link GenericError} response, keyed by the field at fault.
+ */
 @Slf4j
 @RestControllerAdvice
 public class RestExceptionHandler {
 
+    private static final String FALLBACK_FIELD = "body";
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<GenericError> handleException(Exception e) {
         log.error("Exception occurred", e);
-        var message = toMessages(e.getMessage());
         if (e instanceof ApplicationException ex) {
-            return switch (ex) {
-                case BadRequestException _ -> responseEntity(HttpStatus.UNPROCESSABLE_CONTENT, message);
-                case ForbiddenException _ -> responseEntity(HttpStatus.FORBIDDEN, message);
-                case NotFoundException _ -> responseEntity(HttpStatus.NOT_FOUND, message);
-                case UnauthorizedException _ -> responseEntity(HttpStatus.UNAUTHORIZED, message);
+            var status = switch (ex) {
+                case BadRequestException _ -> HttpStatus.UNPROCESSABLE_CONTENT;
+                case ConflictException _ -> HttpStatus.CONFLICT;
+                case ForbiddenException _ -> HttpStatus.FORBIDDEN;
+                case NotFoundException _ -> HttpStatus.NOT_FOUND;
+                case UnauthorizedException _ -> HttpStatus.UNAUTHORIZED;
             };
+            return responseEntity(status, GenericError.of(ex.field(), ex.error()));
         } else if (e instanceof ErrorResponse errorResponse) {
             if (errorResponse instanceof MethodArgumentNotValidException ex) {
                 return handleMethodArgumentNotValid(ex);
@@ -70,17 +79,17 @@ public class RestExceptionHandler {
                 var statusCode = errorResponse.getStatusCode();
                 if (statusCode.isSameCodeAs(HttpStatus.UNAUTHORIZED)
                     || statusCode.isSameCodeAs(HttpStatus.FORBIDDEN)) {
-                    return responseEntity(statusCode, message);
+                    return responseEntity(statusCode, fallback(e));
                 } else if (statusCode.is4xxClientError()) {
-                    return responseEntity(HttpStatus.UNPROCESSABLE_CONTENT, message);
+                    return responseEntity(HttpStatus.UNPROCESSABLE_CONTENT, fallback(e));
                 } else {
-                    return responseEntity(statusCode, message);
+                    return responseEntity(statusCode, fallback(e));
                 }
             }
         } else if (e instanceof ConstraintViolationException ex) {
             return handleConstraintViolation(ex);
         }
-        return responseEntity(HttpStatus.INTERNAL_SERVER_ERROR, message);
+        return responseEntity(HttpStatus.INTERNAL_SERVER_ERROR, fallback(e));
     }
 
     public ResponseEntity<GenericError> handleMethodArgumentNotValid(
@@ -96,27 +105,51 @@ public class RestExceptionHandler {
 
     public ResponseEntity<GenericError> handleConstraintViolation(
             ConstraintViolationException exception) {
-        var errors = exception.getConstraintViolations().stream()
-                .map(ConstraintViolation::getMessage)
+        var pairs = exception.getConstraintViolations().stream()
+                .map(violation -> Map.entry(
+                        leafField(violation.getPropertyPath().toString()),
+                        messageOf(violation)))
                 .toList();
-        return responseEntity(HttpStatus.UNPROCESSABLE_CONTENT, errors);
+        return responseEntity(HttpStatus.UNPROCESSABLE_CONTENT, GenericError.ofPairs(pairs));
+    }
+
+    private static String messageOf(ConstraintViolation<?> violation) {
+        return requireNonNullElse(violation.getMessage(), "is invalid");
     }
 
     private static ResponseEntity<GenericError> responseEntityObjectErrors(
             HttpStatusCode httpStatusCode, List<ObjectError> errors) {
-        var messages = errors.stream()
-                .map(ObjectError::getDefaultMessage)
+        var pairs = errors.stream()
+                .map(error -> Map.entry(fieldOf(error), messageOf(error)))
                 .toList();
-        return responseEntity(httpStatusCode, messages);
+        return responseEntity(httpStatusCode, GenericError.ofPairs(pairs));
     }
 
-    private static List<String> toMessages(@Nullable String message) {
-        return message != null ? List.of(message) : List.of();
+    /**
+     * Resolves the response key from a binding error, using the leaf segment of the property
+     * path.
+     */
+    private static String fieldOf(ObjectError error) {
+        return error instanceof FieldError fieldError
+                ? leafField(fieldError.getField())
+                : FALLBACK_FIELD;
+    }
+
+    private static String leafField(String path) {
+        var leaf = path.substring(path.lastIndexOf('.') + 1);
+        return leaf.isEmpty() ? FALLBACK_FIELD : leaf;
+    }
+
+    private static String messageOf(ObjectError error) {
+        return requireNonNullElse(error.getDefaultMessage(), "is invalid");
+    }
+
+    private static GenericError fallback(Exception e) {
+        return GenericError.of(FALLBACK_FIELD, requireNonNullElse(e.getMessage(), "is invalid"));
     }
 
     private static ResponseEntity<GenericError> responseEntity(
-            HttpStatusCode httpStatusCode, List<String> errors) {
-        var body = new GenericError(new GenericError.Errors(errors));
+            HttpStatusCode httpStatusCode, GenericError body) {
         return ResponseEntity.status(httpStatusCode).body(body);
     }
 

--- a/service/src/test/java/com/github/al/realworld/application/command/Command1.java
+++ b/service/src/test/java/com/github/al/realworld/application/command/Command1.java
@@ -26,4 +26,5 @@ package com.github.al.realworld.application.command;
 import com.github.al.realworld.bus.Command;
 
 public class Command1 implements Command<String> {
+
 }

--- a/service/src/test/java/com/github/al/realworld/application/command/Command1Handler.java
+++ b/service/src/test/java/com/github/al/realworld/application/command/Command1Handler.java
@@ -33,4 +33,5 @@ public class Command1Handler implements CommandHandler<String, Command1> {
     public String handle(Command1 command) {
         return null;
     }
+
 }

--- a/service/src/test/java/com/github/al/realworld/application/command/Command2.java
+++ b/service/src/test/java/com/github/al/realworld/application/command/Command2.java
@@ -26,4 +26,5 @@ package com.github.al.realworld.application.command;
 import com.github.al.realworld.bus.Command;
 
 public class Command2 implements Command<String> {
+
 }

--- a/service/src/test/java/com/github/al/realworld/application/command/Command2Handler.java
+++ b/service/src/test/java/com/github/al/realworld/application/command/Command2Handler.java
@@ -33,4 +33,5 @@ public class Command2Handler implements CommandHandler<String, Command2> {
     public String handle(Command2 command) {
         return null;
     }
+
 }

--- a/service/src/test/java/com/github/al/realworld/bus/Command3.java
+++ b/service/src/test/java/com/github/al/realworld/bus/Command3.java
@@ -24,4 +24,5 @@
 package com.github.al.realworld.bus;
 
 public class Command3 implements Command<String> {
+
 }

--- a/service/src/test/java/com/github/al/realworld/bus/Command3Handler.java
+++ b/service/src/test/java/com/github/al/realworld/bus/Command3Handler.java
@@ -32,4 +32,5 @@ public class Command3Handler implements CommandHandler<String, Command3> {
     public String handle(Command3 command) {
         return "command-3-result";
     }
+
 }

--- a/service/src/test/java/com/github/al/realworld/bus/DefaultBusTest.java
+++ b/service/src/test/java/com/github/al/realworld/bus/DefaultBusTest.java
@@ -41,13 +41,17 @@ class DefaultBusTest {
     }
 
     static class TestCommand1 implements Command<String> {
+
     }
 
     @Component
     public static class TestCommand1Handler implements CommandHandler<String, TestCommand1> {
+
         @Override
         public String handle(TestCommand1 command) {
             return "handle-result-1";
         }
+
     }
+
 }

--- a/service/src/test/java/com/github/al/realworld/infrastructure/json/JsonNullableDeserializerTest.java
+++ b/service/src/test/java/com/github/al/realworld/infrastructure/json/JsonNullableDeserializerTest.java
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - present Alexey Lapin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.al.realworld.infrastructure.json;
+
+import com.github.al.realworld.api.dto.JsonNullable;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonNullableDeserializerTest {
+
+    record Payload(
+            @Nullable JsonNullable<String> bio,
+            @Nullable JsonNullable<List<String>> tagList
+    ) {
+
+    }
+
+    private final JsonMapper mapper = JsonMapper.builder()
+            .addModule(new JsonNullableModule())
+            .build();
+
+    private Payload read(String json) {
+        return mapper.readValue(json, Payload.class);
+    }
+
+    @Test
+    void should_beNullReference_whenPropertyAbsent() {
+        assertThat(read("{}").bio()).isNull();
+    }
+
+    @Test
+    void should_holdNullValue_whenPropertyExplicitlyNull() {
+        var bio = read("{\"bio\":null}").bio();
+
+        assertThat(bio).isNotNull();
+        assertThat(bio.isNull()).isTrue();
+        assertThat(bio.value()).isNull();
+    }
+
+    @Test
+    void should_holdValue_whenPropertyPresent() {
+        assertThat(read("{\"bio\":\"hello\"}").bio()).isEqualTo(new JsonNullable<>("hello"));
+    }
+
+    @Test
+    void should_holdEmptyString_whenPropertyBlank() {
+        assertThat(read("{\"bio\":\"\"}").bio()).isEqualTo(new JsonNullable<>(""));
+    }
+
+    @Test
+    void should_resolveGenericContentType_whenPropertyIsList() {
+        assertThat(read("{\"tagList\":[\"a\",\"b\"]}").tagList())
+                .isEqualTo(new JsonNullable<>(List.of("a", "b")));
+    }
+
+    @Test
+    void should_distinguishEmptyListFromNullAndAbsent() {
+        assertThat(read("{\"tagList\":[]}").tagList()).isEqualTo(new JsonNullable<>(List.<String>of()));
+        assertThat(read("{\"tagList\":null}").tagList()).isEqualTo(new JsonNullable<List<String>>(null));
+        assertThat(read("{}").tagList()).isNull();
+    }
+
+    @Test
+    void should_serializeAsBareValue() {
+        var json = mapper.writeValueAsString(new Payload(new JsonNullable<>("hello"), new JsonNullable<>(null)));
+
+        assertThat(json).isEqualTo("{\"bio\":\"hello\",\"tagList\":null}");
+    }
+
+}


### PR DESCRIPTION
The upstream hurl suite fails 12 of 13 files against the current API. The gaps
are in the contract rather than the behaviour, so this reshapes the error
envelope, status codes and partial-update semantics to match.

Errors are now keyed by the field at fault — {"errors":{"article":["not
found"]}} — instead of a flat {"errors":{"body":[...]}} of free text. Each
ApplicationException carries the spec's field/error pair alongside its own
message, so the detail that used to reach clients now goes to the log only.
Bean Validation messages become "can't be blank" and are reported under the
leaf property name.

Status codes: 204 for both deletes, 201 for adding a comment, and a new
ConflictException gives 409 on a duplicate username or email. An unknown email
at login returns 401 credentials/invalid, the same as a wrong password, so the
endpoint cannot be used to enumerate users.

Unauthenticated requests are rejected by the filter chain before the controller
advice can see them, which is why they had an empty body.
ApiAuthenticationEntryPoint now writes the envelope itself, and is registered
on the resource server too — the bearer-token filter carries its own entry
point and never consults the one on exceptionHandling, so otherwise only a
missing header reached it and an invalid token still got a bare 401.

Partial updates need to tell an omitted property apart from one explicitly set
to null: PUT /user {"bio":null} clears the bio while omitting bio keeps it, and
{"email":null} is rejected outright. Neither Optional nor
@JsonSetter(nulls = FAIL) can express that under Jackson 3 — both collapse
absent and null — so JsonNullable<T> carries the distinction via getNullValue
and getAbsentValue. Empty strings for bio and image normalise to null, and
passwords follow NIST 800-63B: at least 8 characters, at least 64 accepted.

Only reading a JsonNullable needs jackson-databind; writing needs @JsonValue
alone. Its deserializer therefore lives in the service module and registers as
a JacksonModule bean, which also keeps the databind-resident @JsonDeserialize
annotation off the type, so service-api stays on jackson-annotations.
JsonNullableValueExtractor teaches Bean Validation to look inside the wrapper,
so constraints such as @Email keep working on wrapped fields; rules that need
the absent/null distinction stay in the handlers, since an extracted null is
indistinguishable from an absent one.

Article tags gain the same treatment: an omitted tagList is preserved, an empty
array clears it, an explicit null is rejected. Clearing needs clearTags() first
because tags is a Lombok @Singular field, so the builder appends rather than
replaces — setting an empty list was a silent no-op and setting a new list
merged it with the old tags.

Deleting a comment now checks the article first, so an unknown slug reports the
article rather than blaming the comment.

User.bio, User.image and their DTO counterparts are annotated @Nullable; they
were always nullable in the database and the model was under-specifying.

The int tests move with the contract: duplicate registration is 409, an unknown
login is 401, and a token naming a deleted user is 401 rather than 422 or 404.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>