### PR TITLE
Make the API spec check gating and document it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,6 @@ jobs:
           sleep 5
 
       - name: Run API spec tests
-        # TODO: drop continue-on-error once the API conforms to the spec.
-        continue-on-error: true
         shell: bash
         run: >
           hurl --test
@@ -156,8 +154,6 @@ jobs:
         shell: bash
 
       - name: Run API spec tests
-        # TODO: drop continue-on-error once the API conforms to the spec.
-        continue-on-error: true
         shell: bash
         run: >
           hurl --test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,30 @@ Aggregated coverage report:
 ./gradlew jacocoReport
 ```
 
+RealWorld API spec compliance (gating in CI, and the thing to run after any
+change to controllers, DTOs, error handling or status codes — `./gradlew check`
+does not cover it):
+
+```bash
+# One-time checkout of the upstream spec into .realworld-spec (gitignored):
+git clone --filter=blob:none --sparse https://github.com/realworld-apps/realworld .realworld-spec
+git -C .realworld-spec sparse-checkout set specs/api
+
+# Pin it to the same revision CI uses, then run the suite against a live app:
+SPEC_REF=$(grep -E '^  SPEC_REF:' .github/workflows/main.yml | awk '{print $2}')
+git -C .realworld-spec fetch origin && git -C .realworld-spec checkout --detach "$SPEC_REF"
+
+./gradlew :service:bootJar
+java -jar service/build/libs/realworld-backend-spring*.jar &
+hurl --test --jobs 1 \
+  --variable host=http://localhost:8080 \
+  --variable uid=$(date +%s) \
+  .realworld-spec/specs/api/hurl/*.hurl
+```
+
+`host` is the origin without `/api`; the `.hurl` files add the prefix. Always run
+the pinned `SPEC_REF` — an older checkout enforces rules upstream has dropped.
+
 ### Run a single test
 
 Use Gradle `--tests` to target a class or method.
@@ -153,6 +177,9 @@ Tip: prefix with `:service:` when iterating locally to avoid running all modules
 - Integration tests live in `service/src/intTest/java` and run via `integrationTest`.
 - Keep test data small and focus on behavior; follow existing naming patterns
   within the same test class.
+- The upstream hurl suite pins the public contract: error envelope shape, status
+  codes and field-level error keys. Changing any of those means running it, since
+  no Gradle task does.
 
 ## When editing
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ The project features a comprehensive automated pipeline:
 - Multi-platform builds: JVM JAR + native executables for 4 platforms
 - Automated testing with JUnit and integration tests
 - RealWorld spec compliance verification
-  via [Postman collection](https://github.com/gothinkster/realworld/blob/master/api/Conduit.postman_collection.json)
-  with newman
+  via the upstream [hurl collection](https://github.com/realworld-apps/realworld/tree/main/specs/api)
 - Code coverage tracking with [Codecov](https://codecov.io/gh/alexey-lapin/realworld-backend-spring)
 - Docker image building and publishing
   to [GitHub Container Registry](https://github.com/alexey-lapin/realworld-backend-spring/pkgs/container/realworld-backend-spring)
@@ -154,15 +153,50 @@ testing:
 # Run integration tests
 ./gradlew integrationTest
 
-# Build and run newman tests
+# Verify against the RealWorld API spec (needs https://hurl.dev installed).
+# The spec lives upstream; check it out into .realworld-spec, the same path CI
+# uses. The revision is read from the workflow rather than repeated here, so a
+# local run and a CI run cannot drift onto different specs.
+SPEC_REF=$(grep -E '^  SPEC_REF:' .github/workflows/main.yml | awk '{print $2}')
+
+# First time only:
+git clone --filter=blob:none --sparse https://github.com/realworld-apps/realworld .realworld-spec
+git -C .realworld-spec sparse-checkout set specs/api
+
+# Before each run (also refreshes an existing checkout):
+git -C .realworld-spec fetch origin && git -C .realworld-spec checkout --detach "$SPEC_REF"
+
 ./gradlew build
+java -jar service/build/libs/realworld-backend-spring*.jar &
+hurl --test --jobs 1 \
+  --variable host=http://localhost:8080 \
+  --variable uid=$(date +%s) \
+  .realworld-spec/specs/api/hurl/*.hurl
 ```
+
+`.realworld-spec` is a foreign clone with its own `.git`, so it is gitignored
+and excluded from the Docker build context. It is about 2 MB.
+
+Two things worth knowing:
+
+- `host` is the origin **without** `/api` — the `.hurl` files append the prefix
+  themselves. Upstream's own README example gets this wrong.
+- **Check out `SPEC_REF`, don't just run whatever the checkout happens to be on.**
+  The spec is a moving target and its requirements change: duplicate article
+  titles once had to return `409`, and now must be accepted with distinct slugs.
+  A stale copy fails locally on rules CI no longer enforces, which looks like a
+  bug in this service and isn't. To move to a newer spec, bump `SPEC_REF` in
+  `.github/workflows/main.yml` deliberately and fix whatever it turns red.
+
+A Bruno collection generated from the same files is available upstream if you
+prefer to explore the requests interactively; the hurl files are the source of
+truth and are what CI runs.
 
 Test suite includes:
 
 - Unit tests for business logic and handlers
 - Integration tests using Spring's declarative HTTP clients
-- RealWorld Postman collection validation
+- RealWorld API spec validation with [hurl](https://hurl.dev)
 - Code coverage reporting via JaCoCo and Codecov
 
 ### Manual API Testing


### PR DESCRIPTION
The hurl step landed as continue-on-error because the API did not yet conform.
It does now, so drop the flag in both jobs and let a regression fail the build.

README still described the Postman/newman setup, including a dead collection
URL. Replace it with the hurl equivalent, pointing at the same .realworld-spec
path CI uses, and read SPEC_REF out of the workflow rather than repeating the
revision, so the local command and the CI pin cannot drift.

Two things that reliably trip people up are now called out: host is the origin
without /api, since the .hurl files add the prefix themselves and upstream's
own README example gets this wrong; and the suite must be run at SPEC_REF
rather than at whatever a checkout happens to sit on. The spec is a moving
target — duplicate article titles once had to return 409 and now must be
accepted with distinct slugs — so a stale copy fails on rules CI no longer
enforces, which looks like a bug in this service and isn't.

AGENTS.md gained the spec run too. It documented every other verification
command but not this one, which is easy to miss precisely because no Gradle
task covers it: ./gradlew check passes while the public contract is broken.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>