### PR TITLE
Migrate versions plugin id to io.github.ben-manes.versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,4 +17,4 @@ springdoc-openapiStarterWebmvcUi = { group = "org.springdoc", name = "springdoc-
 graalvm = { id = "org.graalvm.buildtools.native", version = "1.1.10" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 spring-nullability = { id = "io.spring.nullability", version = "0.0.15" }
-versions = { id = "com.github.ben-manes.versions", version = "0.61.0" }
+versions = { id = "io.github.ben-manes.versions", version = "0.61.0" }


### PR DESCRIPTION
The `com.github.ben-manes.versions` plugin id is deprecated and produces a build warning. The plugin is published under `io.github.ben-manes.versions`, so the catalog entry now points there.

Verified with `./gradlew help` — configuration resolves the plugin and the warning is gone.