### PR TITLE
Replace deprecated Kotlin DSL delegate APIs

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/realworld.jacoco-aggregation.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/realworld.jacoco-aggregation.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // A resolvable configuration to collect source code
-val sourcesPath: Configuration by configurations.creating {
+val sourcesPath = configurations.create("sourcesPath") {
     isCanBeResolved = true
     isCanBeConsumed = false
     extendsFrom(configurations.implementation.get())
@@ -17,7 +17,7 @@ val sourcesPath: Configuration by configurations.creating {
 }
 
 // A resolvable configuration to collect source code
-val classesPath: Configuration by configurations.creating {
+val classesPath = configurations.create("classesPath") {
     isCanBeResolved = true
     isCanBeConsumed = false
     extendsFrom(configurations.implementation.get())
@@ -29,7 +29,7 @@ val classesPath: Configuration by configurations.creating {
 }
 
 // A resolvable configuration to collect JaCoCo coverage data
-val coverageDataPath: Configuration by configurations.creating {
+val coverageDataPath = configurations.create("coverageDataPath") {
     isCanBeResolved = true
     isCanBeConsumed = false
     extendsFrom(configurations.implementation.get())
@@ -41,7 +41,7 @@ val coverageDataPath: Configuration by configurations.creating {
 }
 
 // Task to gather code coverage from multiple subprojects
-val jacocoReport by tasks.registering(JacocoReport::class) {
+val jacocoReport = tasks.register<JacocoReport>("jacocoReport") {
     additionalClassDirs(classesPath.incoming.artifactView { lenient(true) }.files)
     additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
     executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -83,7 +83,7 @@ tasks {
         }
     }
 
-    val writeArtifactFile by registering {
+    val writeArtifactFile = register("writeArtifactFile") {
         doLast {
             val outputDirectory = getByName<BuildNativeImageTask>("nativeCompile").outputDirectory
             outputDirectory.get().asFile.mkdirs()


### PR DESCRIPTION
Gradle 9.6 deprecated the delegated-property forms of the Kotlin DSL — `configurations.creating` and `tasks.registering`. Compiling the convention plugins emitted 12 warnings, all from `realworld.jacoco-aggregation.gradle.kts`. `service/build.gradle.kts` used the same pattern for `writeArtifactFile`.

Switched to `configurations.create(name)` and `tasks.register(name)`, passing the names explicitly so the configurations and tasks keep their existing names.

Verified:
- `:plugins:common:compileKotlin --rerun-tasks` now compiles with 0 warnings (was 12).
- `./gradlew jacocoReport` builds the aggregated report; the `transitiveSourcesElements`, `transitiveCompiledElements` and `coverageDataElements` variants still resolve.
- `:service:writeArtifactFile` still resolves and stays wired to `nativeCompile`.