### PR TITLE
Remove obsolete bootBuildImage configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ env:
   SPEC_REF: 5d510ce6ec41bb97723e92fbd8d3e3458a381c09
   HURL_VERSION: 8.0.1
   CR_REGISTRY: ghcr.io
-  CR_NAMESPACE: ${{ github.repository_owner }}
   CR_USERNAME: ${{ github.actor }}
   CR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import org.gradle.internal.os.OperatingSystem
-import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
@@ -66,21 +65,6 @@ springBoot {
 tasks {
     named<BootJar>("bootJar") {
         archiveFileName.set("${rootProject.name}-${archiveVersion.get()}.${archiveExtension.get()}")
-    }
-
-    named<BootBuildImage>("bootBuildImage") {
-        val registry = System.getenv("CR_REGISTRY")!!
-        val namespace = System.getenv("CR_NAMESPACE")!!
-        imageName = "${registry}/${namespace}/${rootProject.name}:${project.version}"
-        publish = true
-        tags = setOf("${registry}/${namespace}/${rootProject.name}:latest")
-        docker {
-            publishRegistry {
-                url = System.getenv("CR_REGISTRY")
-                username = System.getenv("CR_USERNAME")
-                password = System.getenv("CR_PASSWORD")
-            }
-        }
     }
 
     val writeArtifactFile = register("writeArtifactFile") {


### PR DESCRIPTION
The bootBuildImage task was added in cad9dac when container images were
built by Spring Boot buildpacks from Gradle. CI now builds the image from
Dockerfile.native with docker/build-push-action, so nothing invokes this
task any more - not the workflow, not README.md, not AGENTS.md.

Beyond being dead, it was a hazard: System.getenv("CR_REGISTRY")!! throws
an NPE whenever the task is realized without those variables set, which
happens on plain `./gradlew tasks` and on IDE project sync.

CR_NAMESPACE existed only to feed this task and is dropped with it. The
remaining CR_* variables are still consumed by docker/login-action.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>