### PR TITLE
Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,10 @@ env:
   SPEC_REPO: realworld-apps/realworld
   SPEC_REF: 5d510ce6ec41bb97723e92fbd8d3e3458a381c09
   HURL_VERSION: 8.0.1
-  CR_REGISTRY: ghcr.io
-  CR_USERNAME: ${{ github.actor }}
-  CR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+# Least privilege by default; jobs that need more elevate individually.
+permissions:
+  contents: read
 
 jobs:
   build-jvm:
@@ -190,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-jvm, build-native]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -240,6 +243,13 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build-native]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CR_REGISTRY: ghcr.io
+      CR_USERNAME: ${{ github.actor }}
+      CR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The workflow had no permissions block at all, so every job ran with
whatever the repository default grants - potentially write access to
contents, packages and more, in jobs that only ever read.

Default to contents: read at the workflow level and elevate the two jobs
that genuinely need more: release creates a GitHub release (contents:
write) and build-docker pushes to ghcr.io (packages: write). labeler.yml
already followed this pattern; main.yml was the outlier.

The registry credentials move down into build-docker for the same reason.
As workflow-level env they were exported into every step of every job,
including the ones that never touch a registry.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>