### PR TITLE
Fail the job when the Render deploy trigger errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -293,5 +293,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy on Render
-        run: |
-          curl -X POST ${{ secrets.RENDER_WEBHOOK }}
+        env:
+          RENDER_WEBHOOK: ${{ secrets.RENDER_WEBHOOK }}
+        run: curl --fail --silent --show-error --request POST "$RENDER_WEBHOOK"


### PR DESCRIPTION
curl without -f exits 0 on a 4xx or 5xx response, so a rejected or
misrouted deploy hook left the job green and the release looked complete.
-f makes the HTTP status decide the exit code, and -sS keeps the output
quiet while still printing the error when one occurs.

Passing the webhook through env rather than interpolating it into the run
body also keeps the secret out of the generated shell script.

Also adds the missing trailing newline at end of file.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>