### PR TITLE
Fold the coverage job into build-jvm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Gradle build
-        run: ./gradlew build
+        run: ./gradlew build jacocoReport
+
+      - name: Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run app for testing
         run: |
@@ -161,31 +166,6 @@ jobs:
           --variable host=http://localhost:8080
           --variable uid=${{ github.run_id }}${{ strategy.job-index }}
           .realworld-spec/specs/api/hurl/*.hurl
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup JDK
-        uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 25
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Gradle jacocoReport
-        shell: bash
-        run: |
-          ./gradlew --version
-          ./gradlew --scan --no-parallel --stacktrace --warning-mode=all jacocoReport
-
-      - name: Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The coverage job allocated a second ubuntu-latest runner, installed the
same JDK 25 and re-ran the entire test suite that build-jvm had just run,
only to produce a JaCoCo report from it. Running `build jacocoReport` in
one invocation gives the same report for one execution of the tests.

The dropped flags were leftovers from an old investigation: --version as
a separate step, plus --no-parallel --stacktrace --warning-mode=all. The
--scan in particular never published anything, since that needs
build-scan-publish on gradle/actions/setup-gradle.

Coverage now also reports against a real version, as build-jvm checks out
with fetch-depth: 0 and the coverage job did not, leaving axion-release
without tags.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>