### PR TITLE
Download only the artifacts the image build consumes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,6 +236,8 @@ jobs:
 
       - name: Download Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: app-native-linux-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
build-docker downloaded all five artifacts - the 45MB jar plus the macOS
and Windows executables - to feed two of them to Dockerfile.native, which
reads app-native-linux-${TARGETARCH} and nothing else.

The pattern keeps the per-artifact directory layout the Dockerfile expects,
so the build context is unchanged apart from no longer carrying the files
it never opens.

release still downloads everything, since it publishes all of them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>