### PR TITLE
Cancel superseded PR runs and cap job runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,14 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-jvm:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -101,6 +106,7 @@ jobs:
             artifact: app-native-macos-arm64
     runs-on: ${{ matrix.os }}
     name: build-native-${{ matrix.name }}
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -169,6 +175,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [build-jvm, build-native]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -221,6 +228,7 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build-native]
     permissions:


### PR DESCRIPTION
Every push to a pull request started a fresh set of four native builds
while the previous set kept running to completion. Keying the concurrency
group on the ref collapses those to the newest run.

cancel-in-progress is deliberately limited to pull_request events. A push
to master or a tag must never be cancelled by a later one, or a release
can be interrupted between publishing artifacts and pushing the image.

The timeouts replace the 6 hour default. build-native gets the widest
budget since native-image is the slow step and the one known to hang -
the -H:DeadlockWatchdogInterval=120 build arg is there for that reason.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>