### PR TITLE
Wait for readiness and resolve artifact paths explicitly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,9 +67,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run app for testing
+        shell: bash
         run: |
           nohup java -jar service/build/libs/realworld-backend-spring*.jar &
-          sleep 5
+          for _ in {1..60}; do
+            curl --fail --silent --output /dev/null http://localhost:8080/actuator/health && exit 0
+            sleep 1
+          done
+          echo "::error::app did not become healthy within 60s"
+          exit 1
 
       - name: Run API spec tests
         shell: bash
@@ -146,23 +152,29 @@ jobs:
         run: ./gradlew :service:nativeCompile -x check
 
       - name: Prepare Artifacts
+        shell: bash
         run: |
-          mkdir /tmp/${{ matrix.artifact }}
-          cp **/build/native/nativeCompile/${{ env.APP_NAME }}* /tmp/${{ matrix.artifact }}
-          cp **/build/native/nativeCompile/gradle-artifact.txt /tmp/${{ matrix.artifact }}
+          mkdir -p "${{ runner.temp }}/${{ matrix.artifact }}"
+          cp service/build/native/nativeCompile/${{ env.APP_NAME }}* "${{ runner.temp }}/${{ matrix.artifact }}"
+          cp service/build/native/nativeCompile/gradle-artifact.txt "${{ runner.temp }}/${{ matrix.artifact }}"
 
       - name: Upload app-native
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |
-            /tmp/${{ matrix.artifact }}/*
+            ${{ runner.temp }}/${{ matrix.artifact }}/*
 
       - name: Run app for testing
+        shell: bash
         run: |
           nohup ./service/build/native/nativeCompile/realworld-backend-spring* &
-          sleep 5
-        shell: bash
+          for _ in {1..60}; do
+            curl --fail --silent --output /dev/null http://localhost:8080/actuator/health && exit 0
+            sleep 1
+          done
+          echo "::error::app did not become healthy within 60s"
+          exit 1
 
       - name: Run API spec tests
         shell: bash


### PR DESCRIPTION
`sleep 5` was a guess about startup time. Locally the jar reaches
UP in about 4 seconds, so on a slower runner the spec tests could start
against a socket that is not listening yet and fail for no real reason.
Polling /actuator/health replaces the guess with the actual condition and
fails loudly if it never comes up. health is already exposed via
management.endpoints.web.exposure.include.

The Prepare Artifacts step relied on two accidents. `**` is not recursive
without globstar, so it was really `*/build/...` and matched only because
service is the sole project that compiles a native image. And with no
shell declared it ran under pwsh on windows-latest, where `cp` is a
Copy-Item alias and `/tmp` resolves to C:\tmp - which happened to line up
with the literal /tmp the upload step passed to Node. Naming the path,
the shell and runner.temp removes all three coincidences.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>