### PR TITLE
Remove dead trigger filter and image tag rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - 'v*.*.*'
   pull_request:
-    branches:
-      - '*'
 
 env:
   APP_NAME: ${{ github.event.repository.name }}
@@ -274,11 +272,12 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # latest=auto follows the newest semver tag and skips pre-releases.
+          flavor: latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v7


### PR DESCRIPTION
The pull_request branches filter matched on '*', which does not match a
slash. A PR opened against a base like release/1.x would have run no CI
at all. The filter applies to the base branch, which is master in every
real case here, so dropping it changes nothing today and removes the trap.

type=raw,value=latest,enable={{is_default_branch}} never fired: the job
only runs when github.ref is refs/tags/*, so is_default_branch is always
false. The latest tag on ghcr comes from the default latest=auto flavor -
latest, 0.4.0, 0.4 and 0 all currently resolve to the same digest, and
0.3.1 to a different one. Stating the flavor explicitly keeps someone
from reintroducing a raw rule that looks necessary but is not.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>