### PR TITLE
Derive release asset names in the workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,6 @@ jobs:
         run: |
           mkdir -p "${{ runner.temp }}/${{ matrix.artifact }}"
           cp service/build/native/nativeCompile/${{ env.APP_NAME }}* "${{ runner.temp }}/${{ matrix.artifact }}"
-          cp service/build/native/nativeCompile/gradle-artifact.txt "${{ runner.temp }}/${{ matrix.artifact }}"
 
       - name: Upload app-native
         uses: actions/upload-artifact@v7
@@ -199,28 +198,20 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v8
 
-      - name: Prepare Linux Artifacts
+      # Platform names come from the artifact directory names set by the matrix.
+      - name: Package Artifacts
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
-          cd app-native-linux-amd64
-          chmod +x ${{ env.APP_NAME }}
-          tar -czf $(cat gradle-artifact.txt).tar.gz ${{ env.APP_NAME }}
-
-      - name: Prepare Linux Artifacts
-        run: |
-          cd app-native-linux-arm64
-          chmod +x ${{ env.APP_NAME }}
-          tar -czf $(cat gradle-artifact.txt).tar.gz ${{ env.APP_NAME }}
-
-      - name: Prepare macOS Artifacts
-        run: |
-          cd app-native-macos-arm64
-          chmod +x ${{ env.APP_NAME }}
-          tar -czf $(cat gradle-artifact.txt).tar.gz ${{ env.APP_NAME }}
-
-      - name: Prepare Windows Artifacts
-        run: |
-          cd app-native-windows-amd64
-          zip $(cat gradle-artifact.txt).zip ${{ env.APP_NAME }}.exe 
+          for dir in app-native-*; do
+            name="${APP_NAME}-${VERSION#v}-${dir#app-native-}"
+            if [ -f "${dir}/${APP_NAME}.exe" ]; then
+              (cd "${dir}" && zip "${name}.zip" "${APP_NAME}.exe")
+            else
+              chmod +x "${dir}/${APP_NAME}"
+              (cd "${dir}" && tar --create --gzip --file "${name}.tar.gz" "${APP_NAME}")
+            fi
+          done
 
       - name: Create Release
         env:
@@ -228,10 +219,8 @@ jobs:
         run: >
           gh release create ${{ github.ref_name }}
           app-jar/*.jar
-          app-native-linux-amd64/*.tar.gz
-          app-native-linux-arm64/*.tar.gz
-          app-native-macos-arm64/*.tar.gz
-          app-native-windows-amd64/*.zip
+          app-native-*/*.tar.gz
+          app-native-*/*.zip
           --title ${{ github.ref_name }}
           --generate-notes
           --fail-on-no-commits

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
-import org.gradle.internal.os.OperatingSystem
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
@@ -65,31 +63,5 @@ springBoot {
 tasks {
     named<BootJar>("bootJar") {
         archiveFileName.set("${rootProject.name}-${archiveVersion.get()}.${archiveExtension.get()}")
-    }
-
-    val writeArtifactFile = register("writeArtifactFile") {
-        doLast {
-            val outputDirectory = getByName<BuildNativeImageTask>("nativeCompile").outputDirectory
-            outputDirectory.get().asFile.mkdirs()
-            outputDirectory.file("gradle-artifact.txt")
-                .get().asFile
-                .writeText("${rootProject.name}-${project.version}-${platform()}")
-        }
-    }
-
-    named("nativeCompile") {
-        finalizedBy(writeArtifactFile)
-    }
-
-}
-
-fun platform(): String {
-    val os = OperatingSystem.current()
-    val arc = System.getProperty("os.arch")
-    return when {
-        OperatingSystem.current().isWindows -> "windows-${arc}"
-        OperatingSystem.current().isLinux -> "linux-${arc}"
-        OperatingSystem.current().isMacOsX -> "darwin-${arc}"
-        else -> os.nativePrefix
     }
 }


### PR DESCRIPTION
gradle-artifact.txt existed only to carry a name-version-platform string
from Gradle into the release job. The release job runs solely on v*.*.*
tags, so the version is github.ref_name, and the platform is already in
the artifact directory name. Nothing had to be passed between them.

That removes writeArtifactFile, the finalizedBy hook on nativeCompile,
the platform() helper and two imports, and collapses four near-identical
prepare steps - two of which shared the name "Prepare Linux Artifacts" -
into one loop.

It also settles a naming split. platform() built its string from the JVM's
os.arch, producing linux-aarch64 and darwin-aarch64, while the matrix,
the Dockerfile's TARGETARCH and the buildx platforms list all say arm64.
Assets now follow the matrix, so linux-aarch64 becomes linux-arm64 and
darwin-aarch64 becomes macos-arm64 from the next release on. Nothing in
the repository referenced the old names.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>