### PR TITLE
Collapse Dockerfile.native to a single stage

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,15 +1,12 @@
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base:latest AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest
 
 ARG TARGETARCH
 ARG APP_NAME
 
-COPY app-native-linux-${TARGETARCH}/${APP_NAME} /app
+# --chmod restores the exec bit, which upload-artifact drops.
+COPY --chmod=755 app-native-linux-${TARGETARCH}/${APP_NAME} /app
 
-RUN chmod +x /app
-
-FROM cgr.dev/chainguard/wolfi-base:latest
-
-COPY --from=builder /app /app
+USER nonroot
 
 EXPOSE 8080
 


### PR DESCRIPTION
The builder stage existed only to run chmod +x on the copied binary.
BuildKit, which buildx always provides, does that inline with COPY
--chmod, so the stage, the --platform=$BUILDPLATFORM pin and one base
image pull all go away. The resulting image is identical.

USER nonroot drops the container off root. wolfi-base ships nonroot as
uid 65532, the app listens on 8080 so no privileged port is involved, and
with no datasource configured it runs on in-memory H2 and writes nothing
to the filesystem.

Also adds the missing trailing newline at end of file.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>