### PR TITLE
Let Renovate track the API spec ref and hurl version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "schedule:daily",
     ":semanticPrefixChore",
     ":label(chore)"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [".github/workflows/main.yml"],
+      "matchStrings": ["SPEC_REF: (?<currentDigest>[0-9a-f]{40})"],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "realworld-apps/realworld",
+      "packageNameTemplate": "https://github.com/realworld-apps/realworld",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [".github/workflows/main.yml"],
+      "matchStrings": ["HURL_VERSION: (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "Orange-OpenSource/hurl",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["realworld-apps/realworld"],
+      "extends": ["schedule:weekly"]
+    }
   ]
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   APP_NAME: ${{ github.event.repository.name }}
-  # RealWorld API spec (hurl collection), pinned to a known-good revision.
+  # RealWorld API spec (hurl collection), pinned to a main-branch commit; Renovate bumps SPEC_REF.
   SPEC_REPO: realworld-apps/realworld
   SPEC_REF: 5d510ce6ec41bb97723e92fbd8d3e3458a381c09
   HURL_VERSION: 8.0.1


### PR DESCRIPTION
`SPEC_REF` and `HURL_VERSION` in `main.yml` were both updated by hand. Two custom Renovate managers now keep them current.

**Spec ref.** `realworld-apps/realworld` publishes no tags and no releases, so a version datasource is not an option — the pin is tracked as a `git-refs` digest against `main`. A digest cannot be scoped to a subpath, so any upstream commit produces a PR even when nothing under `specs/api/hurl` changed; a `packageRules` entry drops this dep to a weekly schedule to keep that in check. CI runs the hurl suite on every PR, so a green bump is a safe merge and a red one is a real spec change. The current pin is 3 commits behind `main`, so expect one PR shortly after this merges.

**Hurl.** `github-releases` on `Orange-OpenSource/hurl`, which tags bare semver (`8.0.1`, not `v8.0.1`), so the workflow value matches the tag as-is and needs no `extractVersion`. `8.0.1` is the latest, so no PR until upstream ships a new release. The `gacts/install-hurl@v1` action was already covered by the built-in `github-actions` manager.

Also renames the deprecated `config:base` preset to `config:recommended` — it was still being auto-migrated, so no behavior change.

Renovate only reads config from the default branch, so none of this takes effect until merge.