### PR TITLE
Declare the Java toolchain and correct the stated Java version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Links:
 
 ## Scope and modules
 
-- Root project: Gradle multi-module build using Java 17.
+- Root project: Gradle multi-module build using Java 25.
 - Modules: 
   - `service` (Spring Boot app), 
   - `service-api` (DTOs/commands/operations),

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The project features a comprehensive automated pipeline:
 
 ## Getting started
 
-**Requirements:** Java 17 or above
+**Requirements:** Java 25 or above
 
 Choose your preferred way to run the application:
 

--- a/gradle/plugins/common/src/main/kotlin/realworld.java-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/realworld.java-conventions.gradle.kts
@@ -21,9 +21,17 @@ if (hasIntTests) {
     configurations["intTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
 }
 
+val javaVersion = 25
+
 configure<JavaPluginExtension> {
-    sourceCompatibility = JavaVersion.VERSION_25
-    targetCompatibility = JavaVersion.VERSION_25
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(javaVersion)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // fails the build if a newer API leaks in, whatever JDK the toolchain resolves
+    options.release = javaVersion
 }
 
 spotless {


### PR DESCRIPTION
The build pinned `sourceCompatibility` and `targetCompatibility` to 25 but never declared a toolchain, so it compiled with whatever JDK happened to run Gradle and failed on anything older. A toolchain states the requirement where Gradle can act on it, and `options.release` additionally fails the build if an API newer than the target leaks in.

Two documents also still claimed Java 17:

- `README.md` said "Requirements: Java 17 or above". Following it on 17 fails with `UnsupportedClassVersionError`.
- `AGENTS.md` described the build as "using Java 17".

Verified: `./gradlew build` passes and the emitted bytecode is still major version 69.