### PR TITLE
Fix stale RealWorld spec links and platform wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Spring Boot codebase containing real world examples (CRUD, auth, advanced patter
 the *RealWorld* spec and API.
 
 Links:
-- https://github.com/gothinkster/realworld/blob/main/api/openapi.yml
+- https://github.com/realworld-apps/realworld/blob/main/specs/api/openapi.yml
 
 ## Scope and modules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![RealWorld Example App using Spring](example-logo.png)
 
-> **A Spring Boot implementation of the [RealWorld](https://github.com/gothinkster/realworld) API specification.**
+> **A Spring Boot implementation of the [RealWorld](https://github.com/realworld-apps/realworld) API specification.**
 >
 > Built with modern Java 25, Spring Boot 4, and GraalVM native image support for instant startup and minimal resource
 > footprint.
@@ -8,7 +8,7 @@
 [![CI](https://github.com/alexey-lapin/realworld-backend-spring/workflows/CI/badge.svg)](https://github.com/alexey-lapin/realworld-backend-spring/actions)
 [![Codecov](https://codecov.io/gh/alexey-lapin/realworld-backend-spring/branch/master/graph/badge.svg)](https://codecov.io/gh/alexey-lapin/realworld-backend-spring)
 
-A complete implementation of the [RealWorld](https://github.com/gothinkster/realworld) API spec on
+A complete implementation of the [RealWorld](https://github.com/realworld-apps/realworld) API spec on
 **[Spring Boot](https://spring.io/projects/spring-boot)** 4 and Java 25, built and shipped as a GraalVM native image
 alongside the usual JVM jar. Every release is checked against the upstream spec in CI on both, so "complete" is
 machine-verified rather than asserted, and it works with any RealWorld frontend.
@@ -62,20 +62,20 @@ Check out the live application on [**Render**](https://render.com/):
 **Native Compilation:**
 
 - Full GraalVM native image support with optimized runtime hints
-- Multi-platform builds: Linux (AMD64/ARM64), macOS (ARM64), Windows
-- Native Docker images with minimal [Wolfi](https://images.chainguard.dev/directory/image/wolfi-base/overview) base for
-  production deployment
+- Multi-platform builds: Linux (AMD64/ARM64), macOS (ARM64), Windows (AMD64)
+- Native Docker images for linux/amd64 and linux/arm64, on a minimal
+  [Wolfi](https://images.chainguard.dev/directory/image/wolfi-base/overview) base for production deployment
 
 ### CI/CD Pipeline
 
 The project features a comprehensive automated pipeline:
 
-- Multi-platform builds: JVM JAR + native executables for 4 platforms
+- Multi-platform builds: JVM JAR + native executables for four platforms
 - Automated testing with JUnit and integration tests
 - RealWorld spec compliance verification
   via the upstream [hurl collection](https://github.com/realworld-apps/realworld/tree/main/specs/api)
 - Code coverage tracking with [Codecov](https://codecov.io/gh/alexey-lapin/realworld-backend-spring)
-- Docker image building and publishing
+- Multi-arch Docker image building and publishing
   to [GitHub Container Registry](https://github.com/alexey-lapin/realworld-backend-spring/pkgs/container/realworld-backend-spring)
 - Automated [GitHub releases](https://github.com/alexey-lapin/realworld-backend-spring/releases) with platform-specific
   artifacts
@@ -116,11 +116,11 @@ the [releases](https://github.com/alexey-lapin/realworld-backend-spring/releases
 ./realworld-backend-spring
 ```
 
-Available platforms: Linux (AMD64/ARM64), macOS (ARM64), Windows
+Available platforms: Linux (AMD64/ARM64), macOS (ARM64), Windows (AMD64)
 
 ### Docker
 
-Run the containerized native image:
+Run the containerized native image, published for linux/amd64 and linux/arm64:
 
 ```bash
 docker run -p 8080:8080 ghcr.io/alexey-lapin/realworld-backend-spring:latest
@@ -134,7 +134,7 @@ The application will be available at:
 ## Frontend Integration
 
 This backend implements the complete RealWorld API specification and works seamlessly with
-any [RealWorld frontend](https://github.com/gothinkster/realworld).
+any [RealWorld frontend](https://github.com/realworld-apps/realworld).
 
 **API Base URL:** `http://localhost:8080/api`
 


### PR DESCRIPTION
Two small README/AGENTS corrections.

**Spec links.** `gothinkster/realworld` moved to `realworld-apps/realworld`, and the OpenAPI spec moved from `api/` to `specs/api/` in the process. The old org links still redirect, so they work, but the `openapi.yml` path does not — `gothinkster/realworld/blob/main/api/openapi.yml` returns 404 today. That one is in `AGENTS.md`, where a dead spec link is the most expensive kind. Updated three README links and the `AGENTS.md` reference; the rest (the hurl collection, the sparse-clone commands) were already on the new namespace. All four new URLs verified 200.

**Platform claims.** They were uneven in three places:

- Both platform lists gave an architecture for every entry except Windows, which reads as "any Windows" when the release matrix builds `windows-amd64` only.
- The container image is built for `linux/amd64` and `linux/arm64` (`main.yml:277`) and nothing in the README said so, so a reader on an ARM machine had no way to tell whether the `docker run` line applied to them.
- The CI/CD list wrote "4 platforms" against the same count spelled out as a word two sections above.