### PR TITLE
Fix three README commands that do not match the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The project features a comprehensive automated pipeline:
 
 ## Getting started
 
-**Requirements:** Java 25 or above
+**Requirements:** Java 25
 
 Choose your preferred way to run the application:
 
@@ -92,7 +92,7 @@ Choose your preferred way to run the application:
 Traditional Spring Boot application with the full JVM:
 
 ```bash
-./gradlew run
+./gradlew bootRun
 ```
 
 Or download the JAR from the [releases](https://github.com/alexey-lapin/realworld-backend-spring/releases/latest) page:
@@ -146,11 +146,14 @@ filtering are fully supported.
 Three layers of tests: unit tests, integration tests, and compliance against the RealWorld spec itself.
 
 ```bash
-# Run all tests
+# Unit tests
 ./gradlew test
 
-# Run integration tests
+# Integration tests, which are a separate suite and do not run as part of `test`
 ./gradlew integrationTest
+
+# Both suites plus Spotless, the same verification the CI build runs
+./gradlew check
 
 # Verify against the RealWorld API spec (needs https://hurl.dev installed).
 # The spec lives upstream; check it out into .realworld-spec, the same path CI


### PR DESCRIPTION
Three README instructions disagree with the build. All three predate the recent doc work; a claims review turned them up.

**`./gradlew run` does not exist** (`README.md:93`). No build script applies the `application` plugin, so there is no `run` task — Spring Boot supplies `bootRun`, which `AGENTS.md:33` already documents correctly. This is the first command in the quickstart, so a reader working through the README from the top hits an unresolvable task before anything else.

**`./gradlew test` is not all tests** (`README.md:150`). It sat under "Three layers of tests" labelled "Run all tests", but integration tests are a separate `JvmTestSuite` wired to `check` (`service/build.gradle.kts:40,61`), not to `test`. The documented command reports green without running them. Both suites are now labelled for what they are, plus `check` for the pair with Spotless.

**"Java 25 or above"** (`README.md:86`) implied a minimum version. The toolchain requests exactly 25 (`realworld.java-conventions.gradle.kts:8`) and no download resolver is configured, so a newer JDK on its own fails to build. Now just `Java 25`.

Task names verified against `./gradlew :service:tasks --all`: `bootRun`, `check`, `integrationTest` and `test` are all present, `run` is not.