### PR TITLE
Scope the CI badge to master pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Built with modern Java 25, Spring Boot 4, and GraalVM native image support for instant startup and minimal resource
 > footprint.
 
-[![CI](https://github.com/alexey-lapin/realworld-backend-spring/workflows/CI/badge.svg)](https://github.com/alexey-lapin/realworld-backend-spring/actions)
+[![CI](https://github.com/alexey-lapin/realworld-backend-spring/actions/workflows/main.yml/badge.svg?branch=master&event=push)](https://github.com/alexey-lapin/realworld-backend-spring/actions/workflows/main.yml?query=branch%3Amaster+event%3Apush)
 [![Codecov](https://codecov.io/gh/alexey-lapin/realworld-backend-spring/branch/master/graph/badge.svg)](https://codecov.io/gh/alexey-lapin/realworld-backend-spring)
 
 A complete implementation of the [RealWorld](https://github.com/realworld-apps/realworld) API spec on


### PR DESCRIPTION
Replaces the original contents of this PR. The spec-compliance badge idea is postponed — not worth an extra CI workflow right now.

**The bug.** The README's CI badge URL carries no branch or event filter, so it reports the newest completed CI run on *any* branch — feature branches and Renovate PRs included. This repo cancels in-flight PR runs on force-push (`main.yml:22-24`, `cancel-in-progress`), GitHub renders a cancelled run as **failing**, and the front page goes red while master is green.

Observed today by reading the SVG titles directly:

```
/workflows/CI/badge.svg                 -> CI - failing
...badge.svg?branch=master&event=push   -> CI - passing
```

The red came from run 33589301350, a cancelled run on `feature/readme-quickstart-commands` whose PR had already merged. Every future force-push on a PR will do the same thing.

**The fix.** Scope the badge to `?branch=master&event=push`, and switch to the `actions/workflows/main.yml/badge.svg` URL form, which survives renaming the workflow. The link points at the same filtered query.

One trade-off: the badge reads grey "no status" while a master build is in flight, instead of showing a stale green. That seems right for a badge whose job is to say whether master is healthy.